### PR TITLE
MTL-1545 doc updates

### DIFF
--- a/CASMREL-776-CSM12-NCN-boot-order-backport/lib/version.sh
+++ b/CASMREL-776-CSM12-NCN-boot-order-backport/lib/version.sh
@@ -2,7 +2,7 @@
 
 # Copyright 2020 Hewlett Packard Enterprise Development LP
 
-: "${RELEASE:="${RELEASE_NAME:="casmrel-776"}-${RELEASE_VERSION:="1.1.0"}"}"
+: "${RELEASE:="${RELEASE_NAME:="casmrel-776"}-${RELEASE_VERSION:="1.1.1"}"}"
 
 # return if sourced
 return 0 2>/dev/null

--- a/CASMREL-776-CSM12-NCN-boot-order-backport/scripts/lib.sh
+++ b/CASMREL-776-CSM12-NCN-boot-order-backport/scripts/lib.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# Permalink to original lib: https://github.com/Cray-HPE/node-image-build/blob/8ec558f712bd894792758058fbdabdb6c2addf38/boxes/ncn-common/files/scripts/common/lib.sh
 function mprint {
     printf '[% -25s] %s\n' "$0" "$1"
 }

--- a/CASMREL-776-CSM12-NCN-boot-order-backport/scripts/mini-install.sh
+++ b/CASMREL-776-CSM12-NCN-boot-order-backport/scripts/mini-install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Author: Russell Bunch <doomslayer@hpe.com>
+# Permalink to original script: https://github.com/Cray-HPE/node-image-build/blob/8ec558f712bd894792758058fbdabdb6c2addf38/boxes/ncn-common/files/scripts/metal/install.sh
 trap "printf >&2 'Metal Install: [ % -20s ]' 'failed'" ERR TERM HUP INT
 trap "echo 'See logfile at: /var/log/cloud-init-metal.log'" EXIT
 set -e


### PR DESCRIPTION
This is just documentation updates for the already submitted hotfix, plus a patch from the current 1.2alpha boot code.
This adds a permalink to the official, public version of the CSM 1.2 scripts.

This also brings in the MTL-1559 fix which was merged into 1.2 NCN Boot code (0.2.21 NCN stable).