### PR TITLE
Casmhms 5480 do not wait for off

### DIFF
--- a/CASMHMS-5480-do-not-wait-for-off/README.md
+++ b/CASMHMS-5480-do-not-wait-for-off/README.md
@@ -1,0 +1,7 @@
+# Do not wait for components to power Off before returning control to user/BOS
+
+This hotfix applies to CSM 1.0.X (Shasta 1.5)
+
+## How to install
+
+Run the `./install-hotfix.sh` script in this hotfix.

--- a/CASMHMS-5480-do-not-wait-for-off/docker/index.yaml
+++ b/CASMHMS-5480-do-not-wait-for-off/docker/index.yaml
@@ -1,0 +1,5 @@
+artifactory.algol60.net/csm-docker/stable:
+  tls-verify: true
+  images:
+    cray-capmc:
+    - 1.31.1

--- a/CASMHMS-5480-do-not-wait-for-off/docker/index.yaml
+++ b/CASMHMS-5480-do-not-wait-for-off/docker/index.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 artifactory.algol60.net/csm-docker/stable:
   tls-verify: true
   images:

--- a/CASMHMS-5480-do-not-wait-for-off/docker/transform.sh
+++ b/CASMHMS-5480-do-not-wait-for-off/docker/transform.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Moves docker directories to locations where helm charts will be expecting them
+
+set -e
+
+DISTDIR=$1
+
+# Transform images to 1.4 dtr.dev.cray.com structure
+(
+	cd "${DISTDIR}"
+	mkdir dtr.dev.cray.com
+	mv -v artifactory.algol60.net/csm-docker/stable/ dtr.dev.cray.com/cray/
+)

--- a/CASMHMS-5480-do-not-wait-for-off/docker/transform.sh
+++ b/CASMHMS-5480-do-not-wait-for-off/docker/transform.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-
+#
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,7 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-
+#
 # Moves docker directories to locations where helm charts will be expecting them
 
 set -e

--- a/CASMHMS-5480-do-not-wait-for-off/helm/index.yaml
+++ b/CASMHMS-5480-do-not-wait-for-off/helm/index.yaml
@@ -1,0 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+https://artifactory.algol60.net/artifactory/csm-helm-charts/:
+  charts:
+    cray-hms-capmc:
+    - 1.23.12

--- a/CASMHMS-5480-do-not-wait-for-off/install-hotfix.sh
+++ b/CASMHMS-5480-do-not-wait-for-off/install-hotfix.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${ROOTDIR}/lib/version.sh"
+
+# Create scratch space
+workdir="$(mktemp -d)"
+trap "rm -fr '${workdir}'" EXIT
+
+# Patch sysmgmt manifest
+kubectl -n loftsman get cm loftsman-sysmgmt -o jsonpath='{.data.manifest\.yaml}' > "${workdir}/sysmgmt.yaml"
+# Update cray-hms-capmc
+yq w -i "${workdir}/sysmgmt.yaml" 'spec.charts.(name==cray-hms-capmc).version' 1.23.12
+yq w -i "${workdir}/sysmgmt.yaml" 'spec.charts.(name==cray-hms-capmc).values.global.appVersion' 1.31.1
+
+# get all installed csm version into a file
+kubectl get cm -n services cray-product-catalog -o json | jq  -r '.data.csm' | yq r -  -d '*' -j | jq -r 'keys[]' > /tmp/csm_versions
+# sort -V: version sort
+highest_version=$(sort -V /tmp/csm_versions | tail -1)
+
+if [[ "$highest_version" == "1.0"*  ]];then
+    echo "patch 1.0 manifest"
+    yq w -i "${workdir}/sysmgmt.yaml"  'spec.sources.charts(name==csm).location' https://packages.local/repository/charts
+    yq w -i "${workdir}/sysmgmt.yaml"  'spec.sources.charts(name==csm).type' repo
+    yq w -i "${workdir}/sysmgmt.yaml"  'spec.sources.charts(name==csm-algol60).location' https://packages.local/repository/charts
+    yq w -i "${workdir}/sysmgmt.yaml"  'spec.sources.charts(name==csm-algol60).type' repo
+fi
+
+# Load artifacts into nexus
+${ROOTDIR}/lib/setup-nexus.sh
+
+function deploy() {
+    while [[ $# -gt 0 ]]; do
+        loftsman ship --charts-repo https://packages.local/repository/charts --manifest-path "$1"
+        shift
+    done
+}
+
+# Redeploy sysmgmt
+deploy "${workdir}/sysmgmt.yaml"
+
+set +x
+cat >&2 <<EOF
++ CSM applications and services upgraded
+${0##*/}: OK
+EOF

--- a/CASMHMS-5480-do-not-wait-for-off/install-hotfix.sh
+++ b/CASMHMS-5480-do-not-wait-for-off/install-hotfix.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 #
 # MIT License
 #

--- a/CASMHMS-5480-do-not-wait-for-off/lib/install.sh
+++ b/CASMHMS-5480-do-not-wait-for-off/lib/install.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Hewlett Packard Enterprise Development LP
+
+# Defaults
+# TODO grab these from customizations.yaml?
+: "${NEXUS_URL:="https://packages.local"}"
+: "${NEXUS_REGISTRY:="registry.local"}"
+
+# Set ROOTDIR to reasonable default, assumes this script is in a subdir (e.g., lib)
+: "${ROOTDIR:="$(dirname "${BASH_SOURCE[0]}")/.."}"
+
+# Prefer to use podman, but for environments with docker
+if [[ "${USE_DOCKER_NOT_PODMAN:-"no"}" == "yes" ]]; then
+    echo >&2 "warning: using docker, not podman"
+    shopt -s expand_aliases
+    alias podman=docker
+fi
+
+function requires() {
+    while [[ $# -gt 0 ]]; do
+        command -v "$1" >/dev/null 2>&1 || {
+            echo >&2 "command not found: ${1}"
+            exit 1
+        }
+        shift
+    done
+}
+
+requires curl find podman realpath
+
+# usage: load-vendor-image TARFILE
+#
+# Loads a vendored container image TARFILE saved using "docker save" into
+# podman's runtime to facilitate installation.
+function load-vendor-image() {
+    (
+        set -o pipefail
+        podman load -q -i "$1" 2>/dev/null | sed -e 's/^.*: //'
+    )
+}
+
+vendor_images=()
+
+function load-install-deps() {
+    # Load vendor images to support installation
+    if [[ -f "${ROOTDIR}/vendor/cray-nexus-setup.tar" ]]; then
+        [[ -v CRAY_NEXUS_SETUP_IMAGE ]] || CRAY_NEXUS_SETUP_IMAGE="$(load-vendor-image "${ROOTDIR}/vendor/cray-nexus-setup.tar")" || return
+        vendor_images+=("$CRAY_NEXUS_SETUP_IMAGE")
+    fi
+
+    if [[ -f "${ROOTDIR}/vendor/skopeo.tar" ]]; then
+        [[ -v SKOPEO_IMAGE ]] || SKOPEO_IMAGE="$(load-vendor-image "${ROOTDIR}/vendor/skopeo.tar")" || return
+        vendor_images+=("$SKOPEO_IMAGE")
+    fi
+}
+
+function clean-install-deps() {
+    # Clean images used to support installation
+    for image in "${vendor_images[@]}"; do
+        podman rmi -f "$image"
+    done
+}
+
+# usage: nexus-setup (blobstores|repositories) CONFIG
+#
+# Sets up Nexus blob stores or repositories given CONFIG, a valid configuration
+# YAML file where each document is valid HTTP POST data to the respective Nexus
+# REST API:
+#
+# - Blob stores: /service/rest/beta/blobstores/<type>[/<name>]
+# - Repositories: /service/rest/beta/repositories/<format>/<type>[/<name>]
+#
+# Requires the following environment variables to be set:
+#
+#   NEXUS_URL - Base Nexus URL; defaults to https://packages.local
+#   CRAY_NEXUS_SETUP_IMAGE - Image containing Cray's Nexus setup tools;
+#       recommended to vendor with tag specific to a product version
+#
+function nexus-setup() {
+    podman run --rm --network host \
+        -v "$(realpath "$2"):/config.yaml:ro" \
+        -e "NEXUS_URL=${NEXUS_URL}" \
+        "$CRAY_NEXUS_SETUP_IMAGE" \
+        "nexus-${1}-create" /config.yaml
+}
+
+# usage: nexus-wait-for-rpm-repomd REPOSITORY [INTERVAL=5]
+#
+# Waits for RPM repository metadata to exist for given REPOSITORY.
+#
+# Nexus automatically computes RPM repository metadata for yum repositories.
+# Immediately trying to upload RPMs to a yum repository may fail until Nexus
+# generates the initial repository metadata. This function checks for
+# repodata/repomd.xml to exist from the repository's root path before
+# returning. It sleeps INTERVAL seconds (default: 5) in between checks.
+#
+# Requires the following environment variables to be set:
+#
+#   NEXUS_URL - Base Nexus URL; defaults to https://packages.local
+#
+function nexus-wait-for-rpm-repomd() {
+    local reponame="$1"
+    local interval="${2:-5}"
+
+    echo >&2 "Waiting for Nexus to create repository metadata for ${reponame}..."
+    while ! curl -Isf "${NEXUS_URL}/repository/${reponame}/repodata/repomd.xml" ; do
+        echo >&2 "${reponame} repo metadata is not ready yet..."
+        sleep "$interval"
+    done
+    echo >&2 "OK - ${reponame} repo metadata exists"
+}
+
+# usage: nexus-upload (helm|raw|yum) DIRECTORY REPOSITORY
+#
+# Uploads a DIRECTORY of assets to the specified Nexus REPOSITORY.
+#
+# The REPOSITORY must be of the specified format (i.e., helm, raw, yum) else
+# the upload may not succeed or select the proper files under the given
+# DIRECTORY.
+#
+# Requires the following environment variables to be set:
+#
+#   NEXUS_URL - Base Nexus URL; defaults to https://packages.local
+#   CRAY_NEXUS_SETUP_IMAGE - Image containing Cray's Nexus setup tools;
+#       recommended to vendor with tag specific to a product version
+#
+function nexus-upload() {
+    local repotype="$1"
+    local src="$2"
+    local reponame="$3"
+
+    [[ -d "$src" ]] || return 0
+
+    podman run --rm --network host \
+        -v "$(realpath "$src"):/data:ro" \
+        -e "NEXUS_URL=${NEXUS_URL}" \
+        "$CRAY_NEXUS_SETUP_IMAGE" \
+        "nexus-upload-repo-${repotype}" "/data/" "$reponame"
+}
+
+# usage: skopeo-sync DIRECTORY
+#
+# Uploads a DIRECTORY of container images to the Nexus registry.
+#
+# Requires the following environment variables to be set:
+#
+#   NEXUS_REGISTRY - Hostname of Nexus registry; defaults to registry.local
+#   SKOPEO_IMAGE - Image containing Skopeo tool; recommended to vendor with tag
+#       specific to a product version
+#
+function skopeo-sync() {
+    local src="$1"
+
+    find "$src" -mindepth 1 -maxdepth 1 -type d | while read path; do
+        podman run --rm --network host \
+            -v "$(realpath "$path"):/image:ro" \
+            "$SKOPEO_IMAGE" \
+            sync --scoped --src dir --dest docker --dest-tls-verify=false /image "${NEXUS_REGISTRY}" || return
+    done
+}

--- a/CASMHMS-5480-do-not-wait-for-off/lib/install.sh
+++ b/CASMHMS-5480-do-not-wait-for-off/lib/install.sh
@@ -1,7 +1,27 @@
 #!/usr/bin/env bash
-
-# Copyright 2020 Hewlett Packard Enterprise Development LP
-
+#
+# MIT License
+#
+# (C) Copyright 2020, 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 # Defaults
 # TODO grab these from customizations.yaml?
 : "${NEXUS_URL:="https://packages.local"}"

--- a/CASMHMS-5480-do-not-wait-for-off/lib/setup-nexus.sh
+++ b/CASMHMS-5480-do-not-wait-for-off/lib/setup-nexus.sh
@@ -1,7 +1,27 @@
 #!/usr/bin/env bash
-
-# Copyright 2021 Hewlett Packard Enterprise Development LP
-
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 set -exo pipefail
 
 ROOTDIR="$(dirname "${BASH_SOURCE[0]}")/.."

--- a/CASMHMS-5480-do-not-wait-for-off/lib/setup-nexus.sh
+++ b/CASMHMS-5480-do-not-wait-for-off/lib/setup-nexus.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+
+set -exo pipefail
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")/.."
+source "${ROOTDIR}/lib/install.sh"
+
+load-install-deps
+
+# Upload assets to existing repositories
+skopeo-sync "${ROOTDIR}/docker"
+nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
+
+clean-install-deps
+
+set +x
+cat >&2 <<EOF
++ Nexus setup complete
+setup-nexus.sh: OK
+EOF

--- a/CASMHMS-5480-do-not-wait-for-off/lib/version.sh
+++ b/CASMHMS-5480-do-not-wait-for-off/lib/version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Hewlett Packard Enterprise Development LP
+
+: "${RELEASE:="${RELEASE_NAME:="casmhms-5480"}-${RELEASE_VERSION:="1.31.1"}"}"
+
+# return if sourced
+return 0 2>/dev/null
+
+# otherwise print release information
+if [[ $# -eq 0 ]]; then
+    echo "$RELEASE"
+else
+    case "$1" in
+    -n|--name) echo "$RELEASE_NAME" ;;
+    -v|--version) echo "$RELEASE_VERSION" ;;
+    *)
+        echo >&2 "error: unsupported argumented: $1"
+        echo >&2 "usage: ${0##*/} [--name|--version]"
+        ;;
+    esac
+fi

--- a/CASMHMS-5480-do-not-wait-for-off/lib/version.sh
+++ b/CASMHMS-5480-do-not-wait-for-off/lib/version.sh
@@ -1,7 +1,27 @@
 #!/usr/bin/env bash
-
-# Copyright 2022 Hewlett Packard Enterprise Development LP
-
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 : "${RELEASE:="${RELEASE_NAME:="casmhms-5480"}-${RELEASE_VERSION:="1.31.1"}"}"
 
 # return if sourced


### PR DESCRIPTION
### Summary and Scope

A previous mod implemented support for emulating restarts when the
hardware does not directly support it. It ended up causing every power
off to wait for the hardware to be off. This caused problems due to the
behavior change and a short timeout. Bumped the timeout from 1 minute to
15 minutes. This timeout is still site dependent.

### Issues and Related PRs

* Resolves CASMHMS-5480 for csm 1.0.x

### Testing

Tested on:

* `hela`

Were the install/upgrade based validation checks/tests run? N
Were continuous integration tests run? Y
Was an Upgrade tested?                 Y
Was a Downgrade tested?                Y

Upgraded CAPMC to fixed version, verified CAPMC returns immediately after sending power Off to target node. There were no checks by CAPMC to see if the node was off. Issues a reinit to a node and verified CAPMC waited for the node to power off before issuing the power On and returning. It was discovered on hela that mountain nodes were taking ~11 minutes to power off.

### Risks and Mitigations

HAS A SECURITY AUDIT BEEN RUN? (./runSnyk.sh) Y

No known issues.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

