### PR TITLE
Update 1.3 hotfix to pull in fix for CASMINST-6451 and to apply customizations to manifest before deploy

### DIFF
--- a/CASMREL-1501_FAS-Loader_BOSv2-Power/docker/index.yaml
+++ b/CASMREL-1501_FAS-Loader_BOSv2-Power/docker/index.yaml
@@ -25,7 +25,7 @@ artifactory.algol60.net/csm-docker/stable:
   tls-verify: true
   images:
     cray-bos:
-    - 2.0.16
+    - 2.0.18
     cray-boa:
     - 1.3.5
     cray-firmware-action:

--- a/CASMREL-1501_FAS-Loader_BOSv2-Power/helm/index.yaml
+++ b/CASMREL-1501_FAS-Loader_BOSv2-Power/helm/index.yaml
@@ -26,4 +26,4 @@ https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
     cray-hms-firmware-action:
     - 2.1.6
     cray-bos:
-    - 2.0.16
+    - 2.0.18


### PR DESCRIPTION
## Summary and Scope

This changes the 1.3 hotfix in two ways:

1. Updates the BOS version to include the fix for [https://jira-pro.it.hpe.com:8443/browse/CASMINST-6451](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6451)
2. Modifies the install script so that it applies customization before deploying the manifest. The charts in question are not ones we typically expect to see being customized, but it's possible, so we should do it.
