### PR TITLE
Update hotfix install script to use correct BOS version in manifest

### DIFF
--- a/CASMREL-1501_FAS-Loader_BOSv2-Power/install-hotfix.sh
+++ b/CASMREL-1501_FAS-Loader_BOSv2-Power/install-hotfix.sh
@@ -87,10 +87,10 @@ spec:
       namespace: services
       source: csm-algol60
       timeout: 10m
-      version: 2.0.16
+      version: 2.0.18
       values:
         global:
-          appVersion: 2.0.16
+          appVersion: 2.0.18
   sources:
     charts:
       - location: https://packages.local/repository/charts


### PR DESCRIPTION
## Summary and Scope

I neglected to update the BOS version in the install script in my last PR. I only updated it in the index files. My testing of the install worked because the system where I tested it had both versions available, so it was able to deploy, even with this error. But it will not work on systems that don't have both, which will be most.