### PR TITLE
Use a nicer customer facing name

### DIFF
--- a/CASMTRIAGE-5033/README.md
+++ b/CASMTRIAGE-5033/README.md
@@ -13,7 +13,7 @@ This procedure covers applying the hotfix for the QLogic kernel panics pertainin
 2. On that master node `untar` the tar and change into the CASMTIRAGE-5033 folder
 
    ```bash
-   cd CASMTRIAGE-5033-1.4.1
+   cd csm-1.4.1-qlogic-hotfix-1
    ```
 
 ## Execute the hotfix

--- a/CASMTRIAGE-5033/lib/version.sh
+++ b/CASMTRIAGE-5033/lib/version.sh
@@ -22,7 +22,7 @@
 #  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #  OTHER DEALINGS IN THE SOFTWARE.
 #
-: "${RELEASE:="${RELEASE_NAME:="casmtriage-5033"}-${RELEASE_VERSION:="1.4.1"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.4.1-qlogic-hotfix"}-${RELEASE_VERSION:="1"}"}"
 
 # return if sourced
 return 0 2>/dev/null


### PR DESCRIPTION
Despite CSM Hotfixes using JIRA names already, the name for the QLogic hotfix has been deemed as "icky."

This renames it to match to Greg's manual rename, calling out qlogic and hotfix in the tar name.

This also updates the README so it works with the new name.
