### PR TITLE
CASMTRIAGE-6055 Update CASMTRIAGE-5033 hotfix

### DIFF
--- a/CASMTRIAGE-5033/lib/version.sh
+++ b/CASMTRIAGE-5033/lib/version.sh
@@ -22,7 +22,7 @@
 #  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #  OTHER DEALINGS IN THE SOFTWARE.
 #
-: "${RELEASE:="${RELEASE_NAME:="csm-1.4.1-qlogic-hotfix"}-${RELEASE_VERSION:="1"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.4.1-qlogic-hotfix"}-${RELEASE_VERSION:="2"}"}"
 
 # return if sourced
 return 0 2>/dev/null


### PR DESCRIPTION
Update the CASMTRIAGE-5033 hotfix so that it also:
- Updates the disk bootloader
- Updates S3 and BSS

This will ensure that the patch sticks after reboots.
