### PR TITLE
CASMTRIAGE-6055 CSM 1.4 `craycli` compatibility

### DIFF
--- a/CASMTRIAGE-5033/lib/version.sh
+++ b/CASMTRIAGE-5033/lib/version.sh
@@ -22,7 +22,7 @@
 #  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #  OTHER DEALINGS IN THE SOFTWARE.
 #
-: "${RELEASE:="${RELEASE_NAME:="csm-1.4.1-qlogic-hotfix"}-${RELEASE_VERSION:="2"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.4.1-qlogic-hotfix"}-${RELEASE_VERSION:="3"}"}"
 
 # return if sourced
 return 0 2>/dev/null


### PR DESCRIPTION
CSM 1.4 `craycli` does NOT support multiple `--subrole` parameters.

When the hotfix is invoked, only the last `--subrole` was acknowledged. This meant that only Worker nodes were targeted for the BSS updates.

Follow up to #25 
