### PR TITLE
Remove debug echos

### DIFF
--- a/CASMTRIAGE-5033/install-hotfix.sh
+++ b/CASMTRIAGE-5033/install-hotfix.sh
@@ -86,15 +86,15 @@ function update-bss() {
     echo "Patching BSS bootparameters for [${#ncn_xnames[@]}] NCNs."
     for ncn_xname in "${ncn_xnames[@]}"; do
         printf 'Patching BSS bootparameters %-16s ... ' "${ncn_xname}"
-        echo "curl bss bootparameters list --hosts "${ncn_xname}" --format json | jq '.[]' >"/var/log/qlogic-hotfix/${ncn_xname}.bss.backup.json""
-        echo "curl bss bootparameters update --hosts "${ncn_xname}" --kernel "s3://${bucket}/${fixed_kernel_object}" >/dev/null 2>&1"
-        echo "curl bss bootparameters update --hosts "${ncn_xname}" --initrd "s3://${bucket}/${fixed_initrd_object}" >/dev/null 2>&1"
+        curl bss bootparameters list --hosts "${ncn_xname}" --format json | jq '.[]' >"/var/log/qlogic-hotfix/${ncn_xname}.bss.backup.json"
+        curl bss bootparameters update --hosts "${ncn_xname}" --kernel "s3://${bucket}/${fixed_kernel_object}" >/dev/null 2>&1
+        curl bss bootparameters update --hosts "${ncn_xname}" --initrd "s3://${bucket}/${fixed_initrd_object}" >/dev/null 2>&1
         echo 'Done'
     done
 
     for ncn_xname in "${ncn_xnames[@]}"; do
         echo "$ncn_xname"
-        echo "curl bss bootparameters list --hosts "${ncn_xname}" --format json | jq '.[] | .initrd, .kernel'"
+        curl bss bootparameters list --hosts "${ncn_xname}" --format json | jq '.[] | .initrd, .kernel'
         echo "----------------"
     done
 }


### PR DESCRIPTION
Debug `echo` commands were added in for testing the addition of the `function`, but they were supposed to be removed.
