### PR TITLE
unbound variable

### DIFF
--- a/CASMTRIAGE-5033/install-hotfix.sh
+++ b/CASMTRIAGE-5033/install-hotfix.sh
@@ -43,7 +43,7 @@ else
         exit 1
     fi
 fi
-if [ "$1" != 'upload-only' ]; then
+if [ "${1:-}" != 'upload-only' ]; then
 
     export NCNS=()
     for ncn in "${EXPECTED_NCNS[@]}"; do


### PR DESCRIPTION
```
ncn-m001:/mnt/developer/rusty/csm-1.4.1-qlogic-hotfix-3 # ./install-hotfix.sh
+ '[' -f /etc/pit-release ']'
+ readarray -t EXPECTED_NCNS
++ grep -oP 'ncn-[mw]\d+' /etc/hosts
++ sort -u
+ '[' 14 = 0 ']'
./install-hotfix.sh: line 46: $1: unbound variable
```