### PR TITLE
CASMTRIAGE-6065 Use safer script

### DIFF
--- a/CASMTRIAGE-5033/README.md
+++ b/CASMTRIAGE-5033/README.md
@@ -27,3 +27,31 @@ This hotfix is applied by applying the following script:
 After the script exits successfully, each node the script listed will need to reboot for the patch to take effect.
 
 Please reboot these at your leisure.
+
+## Logs
+
+The script generates log files on the node that it was invoked on.
+
+See `/var/log/qlogic-hotfix/<date>/` for:
+
+- `kernel.upload.log` : Output from uploading the kernel to S3
+- `initrd.upload.log` : Output from uploading the new initrd to S3
+- `patch.xtrace` : Debug output (`set -x`) from the script
+- `$NCN_XNAME.bss.backup.json` : The BSS boot parameters from before the script modified them.
+
+### Restoring BSS boot parameters.
+
+
+1. Change into a desired `/var/log/qlogic-hotfix/<data>` directory.
+1. Run the following:
+
+    ```bash
+    export XNAME="<desired node's xname>"
+    export TOKEN=$(curl -k -s -S -d grant_type=client_credentials \
+      -d client_id=admin-client \
+      -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` \
+      https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token | jq -r '.access_token')
+    curl -i -k -H "Authorization: Bearer ${TOKEN}" -X PUT \
+        https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters \
+        --data @./$XNAME.bss.backup.json
+    ```


### PR DESCRIPTION
The `create-kis-artifacts.sh` script is not safe for fully deployed systems.

Use `create-ims-initrd.sh`, this will not disrupt the running system.

We do need to comment out the lines in the `create-ims-initrd.sh` script that remove the kdump initrd, since we may end up needing that if catastrophy strikes and the system panics while running the hotfix. After the script is called, this restores the original copy of the script.

This was tested on mug, it safely updated the initrd in the right places.