### PR TITLE
CASMREL-1720 hotfix for CASMTRIAGE-6698

### DIFF
--- a/csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698/README.md
+++ b/csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698/README.md
@@ -1,0 +1,40 @@
+# CASMTRIAGE-6698 - cray-hms-rts-snmp pod stuck in CLBO
+
+## Prerequisites
+
+- CSM versions 1.5.0
+  - This fix is included in CSM versions 1.5.1 and up
+
+## Changelog
+
+This hotfix contains the following fixes and enhancements.
+
+- CASMTRIAGE-6698 - cray-hms-rts-snmp pod stuck in CLBO
+  - Fixed concurrency issue associated with RedisActivePipeline
+- CASMHMS-6099 - Add TTL setting to cray-hms-rts-init job
+
+## Installation
+
+The `install-hotfix.sh` script may be run on any Master or Worker Non-Compute Node.
+
+Example:
+
+```bash
+./install-hotfix.sh
+```
+
+## Rollback
+
+To revert `cray-hms-rts` and `cray-hms-rts-snmp` to the previous revisions, select revision numbers to rollback to, for both charts:
+
+```bash
+helm -n services history cray-hms-rts
+helm -n services history cray-hms-rts-snmp
+```
+
+Then perform rollback:
+
+```bash
+helm -n services rollback cray-hms-rts <revision>
+helm -n services rollback cray-hms-rts-snmp <revision>
+```

--- a/csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698/docker/index.yaml
+++ b/csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698/docker/index.yaml
@@ -1,0 +1,7 @@
+artifactory.algol60.net/csm-docker/stable:
+  tls-verify: true
+  images:
+    hms-redfish-translation-service:
+    - 1.24.0
+
+

--- a/csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698/helm/index.yaml
+++ b/csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698/helm/index.yaml
@@ -1,0 +1,5 @@
+https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
+  charts:
+    cray-hms-rts:
+    - 4.0.2
+

--- a/csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698/lib/install.sh
+++ b/csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698/lib/install.sh
@@ -1,0 +1,1 @@
+../.././vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/install.sh

--- a/csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698/lib/setup-nexus.sh
+++ b/csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698/lib/setup-nexus.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+
+set -exo pipefail
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")/.."
+source "${ROOTDIR}/lib/install.sh"
+
+load-install-deps
+
+# Upload assets to existing repositories
+skopeo-sync "${ROOTDIR}/docker" 
+nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
+
+clean-install-deps
+
+set +x
+cat >&2 <<EOF
++ Nexus setup complete
+setup-nexus.sh: OK
+EOF

--- a/csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698/lib/version.sh
+++ b/csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698/lib/version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Hewlett Packard Enterprise Development LP
+
+: "${RELEASE:="${RELEASE_NAME:="csm-1.5.0-cray-hms-rts-CASMTRIAGE-6698"}-${RELEASE_VERSION:="1"}"}"
+
+# return if sourced
+return 0 2>/dev/null
+
+# otherwise print release information
+if [[ $# -eq 0 ]]; then
+    echo "$RELEASE"
+else
+    case "$1" in
+    -n|--name) echo "$RELEASE_NAME" ;;
+    -v|--version) echo "$RELEASE_VERSION" ;;
+    *)
+        echo >&2 "error: unsupported argumented: $1"
+        echo >&2 "usage: ${0##*/} [--name|--version]"
+        ;;
+    esac
+fi


### PR DESCRIPTION
## Summary and Scope

New hotfix published addressing CASMTRIAGE-6698 (originally CAST-34868)

## Issues and Related PRs

* Resolves [CAST-34868](https://jira-pro.it.hpe.com:8443/browse/CAST-34868)
* Resolves [CASMTRIAGE-6698](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6698)

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Before hotfix installation:

    ncn-m001:~ # helm ls -n services | grep cray-hms-rts
    cray-hms-rts                     	services 	1       	2024-03-05 18:23:53.446565465 +0000 UTC	deployed	cray-hms-rts-4.0.0                     	1.23.0
    cray-hms-rts-snmp                	services 	1       	2024-03-05 22:34:12.80981102 +0000 UTC 	deployed	cray-hms-rts-4.0.0                     	1.23.0

After hotfix installation:

    ncn-m001:~ # helm ls -n services | grep cray-hms-rts
    cray-hms-rts                     	services 	2       	2024-03-06 00:50:03.474683356 +0000 UTC	deployed	cray-hms-rts-4.0.2                     	1.24.0
    cray-hms-rts-snmp                	services 	2       	2024-03-06 00:50:09.346680654 +0000 UTC	deployed	cray-hms-rts-4.0.2                     	1.24.0
    
