### PR TITLE
CASMTRIAGE-6716

### DIFF
--- a/CASMTRIAGE-6716/README.md
+++ b/CASMTRIAGE-6716/README.md
@@ -1,0 +1,39 @@
+# CSM 1.5.0 NOOS Repository
+
+Updates the `csm-noos` repository with any RPMs that missed the CSM V1.5.0 official tarball.
+
+This hotfix will:
+* Resolve the repository associated with your CSM 1.5.0 release (e.g. csm-1.5.0-noos, or csm-1.5.0-rc.4-noos for earlier releases)
+* Download all of the artifacts in the remote active repository.
+* Collate this hotfix's RPMs into the downloaded repository.
+* Updates metadata in the collated, local repository.
+    * Installs `createrepo_c` if it is not already installed.
+* **Delete** the remote repository, and the repository group "csm-noos." This helps ensure that nexus doesn't have any issues or conflicts when we upload the artifacts by bringing Nexus's csm-noos to a cleanslate.
+* Recreates the respective csm-noos member repository and the csm-noos repository group.
+* Uploads the artifacts to csm-noos member repository from the local repository .
+
+## JIRA(s)
+
+This hotfix covers the following JIRA(s):
+
+> ***NOTE*** If/when additional RPMs are added, their corresponding JIRAs should be included here.
+
+* [CASMTRIAGE-6716](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6716)
+
+## Usage
+
+### Interactive
+
+Run the script without arguments to witness a deterrent, and interactively accept the hotfix.
+
+```bash
+./install-hotfix.sh
+```
+
+### Non-interactive
+
+Run the script with `-y` to proceed non-interactively.
+
+```bash
+./install-hotfix.sh -y
+```

--- a/CASMTRIAGE-6716/install-hotfix.sh
+++ b/CASMTRIAGE-6716/install-hotfix.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+#  MIT License
+#
+#  (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+set -e
+ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${ROOT_DIR}/lib/version.sh"
+
+function usage {
+
+  cat << EOF
+usage:
+
+./install-hotfix.sh [-y]
+
+Flags:
+-y      Respond with "yes" to any and all prompts; performs a non-interactive run of this script.
+EOF
+}
+
+interactive=1
+while getopts ":y" o; do
+  case "${o}" in
+    y)
+      interactive=0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ "$interactive" -eq 1 ]; then
+    read -r -p "This hotfix will modify the csm-noos repository by destroying and recreating it with additional content added. This is irreversible. Proceed? [y/n]:" response
+    case "$response" in
+        [yY][eE][sS]|[yY])
+            :
+            ;;
+        *)
+            echo 'Exiting cleanly ...'
+            exit 0
+            ;;
+    esac
+else
+    echo 'non-interactive was specified.'
+fi
+
+# Load artifacts into nexus
+"${ROOT_DIR}/lib/setup-nexus.sh"
+
+cat >&2 <<EOF
++ Hotfix installed
+${0##*/}: OK
+EOF

--- a/CASMTRIAGE-6716/lib/install.sh
+++ b/CASMTRIAGE-6716/lib/install.sh
@@ -1,0 +1,1 @@
+../../vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/install.sh

--- a/CASMTRIAGE-6716/lib/setup-nexus.sh
+++ b/CASMTRIAGE-6716/lib/setup-nexus.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+#
+#  MIT License
+#
+#  (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+set -eo pipefail
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")/.."
+source "${ROOTDIR}/lib/install.sh"
+
+requires curl jq
+
+load-install-deps
+
+# Deletes any given nexus repository by name.
+function nexus-delete-repo() {
+    nexus-get-credential
+    local name="${1:-}"
+    local error=0
+    printf >&2 "Deleting %s ..." "$name"
+    if ! curl \
+    -fLs \
+    -u "${NEXUS_USERNAME}":"${NEXUS_PASSWORD}" \
+    -X DELETE \
+    "${NEXUS_URL}/service/rest/v1/repositories/${name}" ; then
+        error=1
+    fi
+    if [ "$error" -ne 0 ]; then
+        echo >&2 'Errors found.'
+    else
+        echo 'Done'
+    fi
+    return "$error"
+}
+
+# Returns the member repository of the CSM noos repository group.
+function get-csm-noos-member {
+    nexus-get-credential
+    local repo_name
+    repo_name=$(curl -fLs -u "${NEXUS_USERNAME}:${NEXUS_PASSWORD}" -X GET "${NEXUS_URL}/service/rest/v1/repositories/raw/group/csm-noos" | jq -r '.group.memberNames[0]')
+    if [ "$repo_name" = 'null' ] || [ -z "$repo_name" ]; then
+        echo >&2 'Could not resolve a member repository for csm-noos!'
+        return 1
+    fi
+    echo "$repo_name"
+}
+
+# Returns a JSON payload of all the artifacts within a given repository.
+function get-artifact-list {
+    nexus-get-credential
+    local repo_name
+    repo_name="$1"
+    if [ -z "$repo_name" ]; then
+        echo >&2 'Can not get artifacts, no repository name was resolved.'
+        return 1
+    fi
+
+    local items
+    local continuationToken
+    response="$(curl -fLs -u "${NEXUS_USERNAME}:${NEXUS_PASSWORD}" -X GET "${NEXUS_URL}/service/rest/v1/components?repository=${repo_name}")"
+    continuationToken="$(jq -n --argjson response "$response" -r '$response.continuationToken')"
+    items="$(jq -n --argjson response "$response" -r '$response.items')"
+    while [ "$continuationToken" != 'null' ]; do
+        response="$(curl -fLs -u "${NEXUS_USERNAME}:${NEXUS_PASSWORD}" -X GET "${NEXUS_URL}/service/rest/v1/components?repository=${repo_name}&continuationToken=${continuationToken}")"
+        continuationToken="$(jq -n --argjson response "$response" -r '$response.continuationToken')"
+        items="$(jq -n --argjson items "$items" --argjson response "$response" '$items + $response.items')"
+    done
+    echo "$items"
+}
+
+# Downloads items based on the Nexus components payload structure and returns their download location.
+function download-items {
+    nexus-get-credential
+    local items
+    local decoded
+    local artifact_path
+    local download_url
+    items="$1"
+    if [ -z "$items" ]; then
+        echo >&2 'No items to download!'
+        return 1
+    fi
+    workdir="$ROOTDIR/$(mktemp -d .rpm-XXXXXXX)"
+    for item in $(jq -r '.[] | @base64' <(echo "$items")); do
+        decoded="$(echo "$item" | base64 --decode | jq -r)"
+        dir="${workdir}$(jq -r '.group' <(echo "$decoded"))"
+        mkdir -p "$dir"
+        download_url="$(jq -r '.assets[0].downloadUrl' <(echo "$decoded"))"
+        artifact_path="$(jq -r '.assets[0].path' <(echo "$decoded"))"
+        curl -fLs -u "${NEXUS_USERNAME}:${NEXUS_PASSWORD}" -o "${workdir}/${artifact_path}" "${download_url}" || return "$?"
+    done
+    echo "$workdir"
+}
+
+function update-repomd {
+    local repository
+    local installed=0
+    repository="$1"
+    if ! command -v createrepo >/dev/null 2>&1 ; then
+        echo >&2 'createrepo was not found, attempting to install dependency ... '
+        installed_packages="$(zypper -n in -y createrepo_c | grep -A 1 'going to be installed' | tail -n 1)"
+        installed=1
+    fi
+    if [ ! -d "$repository" ]; then
+        echo >&2 "Can not update directory [$repository]; does not exist."
+        return 1
+    fi
+    printf 'Updating local repository metadata structure to account for new RPMs ... '
+    if createrepo -q --update "$repository"; then
+        echo 'Done'
+    else
+        echo 'Failed!'
+        return 1
+    fi
+    if [ "$installed" -eq 1 ]; then
+        printf "Cleaning up install of [%s] ... " "$installed_packages"
+        # shellcheck disable=SC2086
+        zypper -q -n remove -y $installed_packages >/dev/null 2>&1
+        echo 'Done'
+    fi
+}
+
+printf 'Resolving repository member for csm-noos ... '
+repository="$(get-csm-noos-member)"
+if [ -n "$repository" ]; then
+    echo 'Done'
+else
+    echo 'Failed!'
+    exit 1
+fi
+
+echo "Working on repository: $repository"
+
+if [ -d "${ROOTDIR}/$repository" ]; then
+    printf "Found [%s] in hotfix directory from previous run. Cleaning ... " "$repository"
+    rm -rf "${ROOTDIR:?}/${repository:?}"
+    echo 'Done'
+fi
+
+printf "Resolving artifacts ... "
+artifacts=$(get-artifact-list "$repository")
+if [ -n "$artifacts" ]; then
+    echo 'Done'
+else
+    echo 'Failed!'
+    exit 1
+fi
+
+printf 'Downloading resolved artifacts ... '
+downloads="$(download-items "$artifacts")"
+if [ ! -d "$downloads" ]; then
+    echo 'Failed!'
+    exit 1
+else
+    mv "$downloads" "$repository"
+    echo 'Done'
+fi
+
+printf 'Copying hotfix RPMs into downloaded repository %s ... ' "$repository"
+if rsync -rltDq "${ROOTDIR}/rpm/" "${ROOTDIR}/${repository}/"; then
+    echo 'Done'
+else
+    echo 'Failed!'
+    exit 1
+fi
+
+update-repomd "$repository" || exit 1
+
+nexus-delete-repo csm-noos
+nexus-delete-repo "$repository"
+
+export repository
+# shellcheck disable=SC2016
+envsubst '$repository' < "${ROOTDIR}/nexus-repositories.template.yaml" > "${ROOTDIR}/nexus-repositories.yaml"
+
+echo "Creating repository [$repository] and repository group [csm-noos] ... "
+nexus-setup repositories "${ROOTDIR}/nexus-repositories.yaml"
+
+echo "Uploading artifacts ... "
+nexus-upload raw "$repository/" "$repository"
+nexus-wait-for-rpm-repomd "$repository"
+
+clean-install-deps
+
+cat >&2 <<EOF
++ Nexus setup complete
+setup-nexus.sh: OK
+EOF

--- a/CASMTRIAGE-6716/lib/version.sh
+++ b/CASMTRIAGE-6716/lib/version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+#  MIT License
+#
+#  (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+: "${RELEASE:="${RELEASE_NAME:="CASMTRIAGE-6716"}-${RELEASE_VERSION:="1.5.0"}"}"
+
+# return if sourced
+return 0 2>/dev/null
+
+# otherwise print release information
+if [[ $# -eq 0 ]]; then
+    echo "$RELEASE"
+else
+    case "$1" in
+    -n|--name) echo "$RELEASE_NAME" ;;
+    -v|--version) echo "$RELEASE_VERSION" ;;
+    *)
+        echo >&2 "error: unsupported argumented: $1"
+        echo >&2 "usage: ${0##*/} [--name|--version]"
+        ;;
+    esac
+fi

--- a/CASMTRIAGE-6716/nexus-repositories.template.yaml
+++ b/CASMTRIAGE-6716/nexus-repositories.template.yaml
@@ -1,0 +1,24 @@
+---
+cleanup: null
+type: hosted
+format: raw
+yum:
+  repodataDepth: 0
+  deployPolicy: STRICT
+name: $repository
+online: true
+storage:
+  blobStoreName: default
+  strictContentTypeValidation: false
+  writePolicy: ALLOW_ONCE
+---
+name: csm-noos
+format: raw
+storage:
+  blobStoreName: csm
+  strictContentTypeValidation: false
+type: group
+online: true
+group:
+  memberNames:
+    - $repository

--- a/CASMTRIAGE-6716/rpm/index.yaml
+++ b/CASMTRIAGE-6716/rpm/index.yaml
@@ -1,0 +1,3 @@
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
+  rpms:
+    - iuf-cli-1.5.11-1.x86_64 


### PR DESCRIPTION
## Summary and Scope

This is a bug fix for CASMTRIAGE-6716 . iuf not exiting with an error when failed.
Giving message "The stage failed, but argo must run to the completion of the stage." 
But not exiting with return code 1 after stage completion.

critical bug fix
It is a backwards compatible bugfix.

## Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6716
* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6554

### Tested on:

  * Local development environment (Starlord)
  * Virtual Shasta(beau)

### Test description:

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
* yes
- Was upgrade tested? 
* yes
- Were new tests (or test issues/Jiras) created for this change?
* yes

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
No

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

