### PR TITLE
CASMTRIAGE-6796 New `metal-ipxe`

### DIFF
--- a/csm-1.5/CASMTRIAGE-6796-csm-pre-install-metal-ipxe/README.md
+++ b/csm-1.5/CASMTRIAGE-6796-csm-pre-install-metal-ipxe/README.md
@@ -1,0 +1,30 @@
+# CSM 1.5.0 Tarball Noos Repository
+
+This hotfix is exclusive to the 1.5.0 fresh install. It is imperative to run this hotfix immediately following the extraction
+of the CSM tarball on the PIT. Specifically, after step 3 of section 2 in the [pre-installation](https://github.com/Cray-HPE/docs-csm/blob/release/1.5/install/pre-installation.md#2-download-and-extract-the-csm-tarball).
+
+This hotfix will:
+* Copy a new `metal-ipxe` package into an extracted CSM tarball.
+* Recreate/update the repodata in the extracted tarball.
+
+After running this hotfix continue installation as usual.
+
+## JIRA(s)
+
+This hotfix covers the following JIRA(s):
+
+> ***NOTE*** If/when additional RPMs are added, their corresponding JIRAs should be included here.
+
+* [CASMTRIAGE-6796](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6796)
+
+## Usage
+
+1. Set `CSM_PATH`, this needs to be the root of the extracted 1.5.0 tarball.
+
+> Example: `/var/www/ephemeral/csm-1.5.0`
+
+1. Run the hotfix.
+
+    ```bash
+    ./install-hotfix.sh -c "$CSM_PATH"
+    ```

--- a/csm-1.5/CASMTRIAGE-6796-csm-pre-install-metal-ipxe/install-hotfix.sh
+++ b/csm-1.5/CASMTRIAGE-6796-csm-pre-install-metal-ipxe/install-hotfix.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+#  MIT License
+#
+#  (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+set -eo pipefail
+ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${ROOT_DIR}/lib/install.sh"
+source "${ROOT_DIR}/lib/version.sh"
+
+function usage {
+
+  cat << EOF
+usage:
+
+./install-hotfix.sh [-v] [-c CSM_PATH]
+
+Flags:
+
+-c              Set the CSM_PATH with a value via the command-line.
+-v              Verbose (run with set -x).
+
+Environment Variables:
+CSM_PATH        The root of the extracted CSM tarball.
+EOF
+}
+
+CSM_PATH="${CSM_PATH:-}"
+while getopts ":vc:" o; do
+  case "${o}" in
+    c)
+      CSM_PATH="${OPTARG}"
+      ;;
+    v)
+      set -x
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ -z "$CSM_PATH" ]; then
+    echo >&2 "CSM_PATH was not set! Aborting."
+    exit 1
+fi
+
+if ! load-install-deps; then
+  echo >&2 'Failed to load installation deps! Hotfix is corrupt.'
+  exit 1
+fi
+
+repository="${CSM_PATH}/rpm/cray/csm/noos"
+if [ ! -d "$repository" ]; then
+    echo >&2 "$repository was not found! Directory does not exist. Tarball needs to be downloaded and extracted before running this hotfix."
+    exit 1
+fi
+printf 'Copying hotfix RPMs into downloaded repository %s ... ' "$repository"
+if rsync -rltDq "${ROOT_DIR}/rpm/" "${repository}/"; then
+    echo 'Done'
+else
+    echo 'Failed!'
+    exit 1
+fi
+
+createrepo "$repository"
+
+boot_script="$(rpm -q --filesbypkg metal-ipxe | awk '/script\.ipxe/{print $NF}')"
+if [ -z "$boot_script" ]; then
+  # No boot script to remove, metal-ipxe is not installed.
+  :
+elif [ -f "$boot_script" ]; then
+  rm -f "$boot_script"
+fi
+
+clean-install-deps
+
+cat >&2 <<EOF
++ Hotfix installed
+${0##*/}: OK
+EOF

--- a/csm-1.5/CASMTRIAGE-6796-csm-pre-install-metal-ipxe/lib/install.sh
+++ b/csm-1.5/CASMTRIAGE-6796-csm-pre-install-metal-ipxe/lib/install.sh
@@ -1,0 +1,1 @@
+../../../vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/install.sh

--- a/csm-1.5/CASMTRIAGE-6796-csm-pre-install-metal-ipxe/lib/version.sh
+++ b/csm-1.5/CASMTRIAGE-6796-csm-pre-install-metal-ipxe/lib/version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+#  MIT License
+#
+#  (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+: "${RELEASE:="${RELEASE_NAME:="CASMTRIAGE-6796-csm-pre-install-metal-ipxe"}-${RELEASE_VERSION:="1"}"}"
+
+# return if sourced
+return 0 2>/dev/null
+
+# otherwise print release information
+if [[ $# -eq 0 ]]; then
+    echo "$RELEASE"
+else
+    case "$1" in
+    -n|--name) echo "$RELEASE_NAME" ;;
+    -v|--version) echo "$RELEASE_VERSION" ;;
+    *)
+        echo >&2 "error: unsupported argumented: $1"
+        echo >&2 "usage: ${0##*/} [--name|--version]"
+        ;;
+    esac
+fi

--- a/csm-1.5/CASMTRIAGE-6796-csm-pre-install-metal-ipxe/rpm/index.yaml
+++ b/csm-1.5/CASMTRIAGE-6796-csm-pre-install-metal-ipxe/rpm/index.yaml
@@ -1,0 +1,3 @@
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos/:
+  rpms:
+    - metal-ipxe-2.4.8-1.noarch


### PR DESCRIPTION
Inserts a [new metal-ipxe](https://github.com/Cray-HPE/metal-ipxe/pull/77) into the CSM tarball.

This way the new metal-ipxe can be included in k8s-nexus, even though it's moot it's at least consistent.

This hotfix must be ran during a fresh install, immediately after the CSM tarball is extracted (this will be noted in the field notice, as well as docs-csm).