### PR TITLE
CASMTRIAGE-6814: restore lib/install.sh for CASMINST-6799 hotfix

### DIFF
--- a/csm-1.5/CASMINST-6799-iuf-race-condition/README.md
+++ b/csm-1.5/CASMINST-6799-iuf-race-condition/README.md
@@ -6,6 +6,13 @@ In CSM 1.5.0, there is a critical bug in IUF which prevents certain stages like 
 
 **You only need to apply this workaround if you are on CSM 1.5.0.** All CSM versions from 1.5.1 onwards have this fix already.
 
+## When to install
+
+You will need to install this hotfix either:
+
+1. Before upgrading products: You will need to install this hotfix after upgrading to CSM 1.5.0, but before beginning any product upgrades with IUF.
+2. After fresh install of CSM 1.5.0: You will need to install this hotfix after fresh install of CSM 1.5.0 and before installation of any other product.
+
 ## How to install
 
 To apply the workaround:

--- a/csm-1.5/CASMINST-6799-iuf-race-condition/lib/install.sh
+++ b/csm-1.5/CASMINST-6799-iuf-race-condition/lib/install.sh
@@ -1,0 +1,1 @@
+../../../vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/install.sh


### PR DESCRIPTION
## Summary and Scope

Hotfix dir for [CASMINST-6799](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6799) is missing `lib/install.sh` symlink to respective file in vendored directory. As a result, hotfix tarball is also missing this file, and hotfix is not installable without a workaround (which is to copy `lib/install.sh` from another hotfix).

## Issues and Related PRs

* Resolves [CASMTRIAGE-6814](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6814)

## Testing
### Tested on:

  * Local development environment

### Test description:

Rebuilt hotfix and ensured `lib/install.sh` is included.

## Risks and Mitigations

Low - install scripts only.
