### PR TITLE
CASMINST-6835 Use tools images from artifactory.algol60.net

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -27,12 +27,6 @@ pipeline {
     stage('Setup') {
       steps {
         sh '''#!/usr/bin/env bash
-          # Pull release tools
-          source "./vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/release.sh"
-          docker pull "$PACKAGING_TOOLS_IMAGE"
-          docker pull "$RPM_TOOLS_IMAGE"
-          docker pull "$SKOPEO_IMAGE"
-
           gcloud auth activate-service-account --key-file ${GOOGLE_APPLICATION_CREDENTIALS}
           gcloud config set core/project csm-release
         '''


### PR DESCRIPTION
## Summary and Scope

Use skopeo, rpm-tools, packaging-tools and cray-nexus-setup from artifactory.algol60.net.

## Issues and Related PRs

* Resolves CASMINST-6835

## Testing
### Tested on:

  * Jenkins

### Test description:

Made a temporary modification, which was already rolled back:
* Adjusted hotfix rebuild criteria to rebuild all 1.5.0 hotfixes
* Vendored https://github.hpe.com/hpe/hpc-shastarelm-release from temporary branch `feature/algol60-auth`

Rebuilt all hotfixes successfully within 2.5 minutes.

## Risks and Mitigations

Low - build/install time change only.

