### PR TITLE
CASMCMS-9097: BOS/CFS scale patch for CSM 1.5

### DIFF
--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
@@ -1,0 +1,165 @@
+# CASMCMS-9097 - Fixes and improvements for large scale CSM systems
+
+## Prerequisites
+
+- CSM versions 1.5.0 to 1.5.2
+
+## Changelog
+
+The list of changes depends on the CSM version on top of which this hotfix is being applied.
+
+(Some of the fixes below are not directly related to the scale issues that are target of this hotfix, but are
+pulled in along with other scale-related fixes)
+
+### CSM 1.5.2
+
+If applying this hotfix on CSM 1.5.2, it contains the following fixes and enhancements:
+
+- BOS
+  - v2
+    - CASMCMS-9067: Add session_limit_required option
+      - This option is disabled by default. If enabled, BOS v2 sessions cannot be created without specifying a limit
+      - This can be used to avoid accidentally creating sessions with no limits specified, if desired
+    - CASMCMS-9052/CASMCMS-9081: Add request timeouts to BOS reporter
+      - This avoids potential hangs by the BOS state reporter, which is used to report to BOS when a node has booted
+    - CASMTRIAGE-7147: Create max_component_batch_size option
+      - This option limits the number of components BOS v2 will include when making API requests
+      - If no limit is in place, then on systems with several thousand nodes, in some cases BOS can generate API
+        requests too large for other services to handle
+      - The default value for this option should be sufficient to avoid this problem
+    - CASMCMS-9039: Fix applystage action
+- CLI
+  - Add support for new BOS v2 options described above
+- Tests
+  - CASMCMS-9029: cmsdev: More securely deal with credentials
+
+### CSM 1.5.1
+
+If applying this hotfix on CSM 1.5.1, it contains all of the fixes and enhancements listed above, as well as the following:
+
+- BOS
+  - v1 and v2
+    - CASMCMS-9015: Instantiate S3 client in a thread-safe manner
+      - Prevents a race condition that can cause some BOS operations to fail soon after full system bringup
+    - CASMTRIAGE-6993: Improve BOS server resiliency and prevent OOM kill issues
+  - v2
+    - CASMCMS-8997: Improve logging
+    - CASMCMS-8998: Optimize operator performance by bypassing unnecessary logic
+- CFS
+  - CASMCMS-8978: Fix bugs causing failures for some component patch requests
+- PCS
+  - CASMHMS-6148: Parse PowerConsumedWatts for any data type and intialize powercap min/max appropriately
+- Tests
+  - CASMCMS-9017: Do not fail BOS test if etcd snapshotter pods are running
+
+### CSM 1.5.0
+
+If applying this hotfix on CSM 1.5.0, it contains all of the fixes and enhancements listed above, as well as the following:
+
+- PCS
+  - CASMHMS-6156: Add POST option to get power states to avoid size limitations with GET parameters
+  - CASMHMS-6146: Generate correct PowerCapURI for Olympus hardware
+- BOS
+  - v2
+    - CASMCMS-8953: Use CFS v3 instead of v2
+    - CASMCMS-8954: Make BOS more efficient when patching CFS components
+    - CASMCMS-8951: Use POST instead of GET when querying PCS for node power status
+    - CASMCMS-8946/CASMCMS-8952: Bypass unnecessary steps in BOS operators; Improve error handling
+    - CASMCMS-8949: Improve logging
+    - CASMCMS-8944: Reduce superfluous S3 calls during v2 session creation
+    - CASMCMS-8941: Break up large CFS component queries to avoid failures
+    - CASMCMS-8916: BOS v2 components patch/put: Fix bug, validate inputs
+    - CASMCMS-8905: Removed unintended ability to update v2 session fields other than status and components
+  - v1
+    - CASMCMS-8274: Gracefully handle CAPMC locked node error
+- CFS
+  - CASMCMS-8966: CFSv3: Fix bug preventing creation of configurations with layers that contain special_parameters
+  - CASMCMS-8964: Prevent false schema errors being logged
+  - CASMCMS-8962: Fix bugs causing failures for some component patch requests
+  - CASMCMS-8920: Fix ARA link for sessions
+- CLI
+  - CASMHMS-6154: Added workaround for setting hostname in HSM
+  - CASMCMS-8905: Remove mistakenly-included BOS v2 sessions update commands
+- Tests
+  - CASMCMS-8958: cmsdev: Add CFS v3 coverage; make v2 testing aware of v3 pagination changes
+- Utilities
+  - CASMTRIAGE-6578: Updated cray-tftp-upload script to handle more than one ipxe pod
+
+## Installation
+
+### Apply hotfix
+
+The `install-hotfix.sh` script may be run on any Master or Worker Non-Compute Node.
+By default, it will update the BOS, CFS, and PCS services, but it will prompt the user about whether or not it
+should patch the csm-noos Nexus RPM repository to include the updated Cray CLI, CMS test, and BOS reporter RPMs.
+This is because in order to include the additional content, the patch script must recreate this repository,
+and that is irreversible.
+
+In order to run the script in non-interactive mode (that is, to avoid being prompted for input), it accepts the following
+mutually exclusive flags:
+
+- `--include-rpms`
+  - Patch the services.
+  - Recreate the Nexus RPM repo to include the updated RPMs.
+- `--no-rpms`
+  - Only patch the services.
+  - Do not add the updated RPMs to Nexus.
+- `--rpms-only`
+  - Do not patch the services. (The relevant charts and images will also not be uploaded to Nexus)
+  - Recreate the Nexus RPM repo to include the updated RPMs.
+
+Example:
+
+```bash
+./install-hotfix.sh
+```
+
+### Update RPMs
+
+The script above copies the updated RPMs into Nexus, but it does not install them on any nodes or images.
+After running the script above, it is recommended to perform the following steps in order to
+begin using the updated RPMs. These steps can be performed on any Kubernetes master or worker NCN where the Cray CLI
+has been authenticated.
+
+These steps are not required, but until they are done, the updated RPMs will not be in use.
+
+1. Install the new version of the Cray CLI and CMS tests by re-running CFS node personalization on the management NCNs.
+
+    For each management NCN, the following will clear its current state in CFS, enable it in CFS, and set its CFS
+    error count to 0. This will cause CFS to re-run on these nodes.
+
+    ```bash
+    cray hsm state components list --role Management --type Node --format json | jq -r '.Components | map(.ID) | join(" ")' |
+        xargs -n 1 cray cfs components update --state '[]' --enabled true --error-count 0 --format json
+    ```
+
+2. Re-customize any images that will be booted using BOS v2.
+
+    > This generally means any images except for management NCN images.
+
+    No changes need to be made to the CFS configurations being used. The CSM layer of the configuration will install the
+    updated BOS reporter RPM when it runs.
+
+    For more information, see
+    - [Create an Image Management Customization CFS Session](https://github.com/Cray-HPE/docs-csm/blob/release/1.4/operations/configuration_management/Create_an_Image_Customization_CFS_Session.md]
+    - [Create UAN Boot Images](https://github.com/Cray-HPE/docs-csm/blob/release/1.4/operations/image_management/Create_UAN_Boot_Images.md)
+
+## Rollback
+
+- To revert BOS to its previous version:
+
+    ```bash
+    helm -n services rollback cray-bos
+    ```
+
+- To revert CFS to its previous version:
+
+    ```bash
+    helm -n services rollback cray-cfs-api
+    ```
+
+- To revert PCS to its previous version:
+
+    ```bash
+    helm -n services rollback cray-power-control
+    ```

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
@@ -1,0 +1,17 @@
+---
+artifactory.algol60.net/csm-docker/stable:
+  tls-verify: true
+  images:
+    cray-boa:
+    - 1.4.4
+    cray-bos:
+    - 2.10.24
+    cray-cfs:
+    - 1.18.6
+    cray-power-control:
+    - 2.4.0
+    cray-power-control-hmth-test:
+    - 2.4.0
+    docker.io/library/redis:
+    - 5.0-alpine
+    - 5.0-alpine3.12

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
@@ -1,0 +1,9 @@
+---
+https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
+  charts:
+    cray-bos:
+    - 2.10.24
+    cray-cfs-api:
+    - 1.18.6
+    cray-power-control:
+    - 2.0.9

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+ROOTDIR=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
+
+REPO_LIST=$(cd "${ROOTDIR}/rpm" ; ls | tr '\n' ' ')
+
+function usage {
+
+cat << EOF
+usage:
+
+./install-hotfix.sh [--include-rpms | --no-rpms | --rpms-only]
+
+If no flags are specified, the script will prompt the user if they
+want the Nexus RPM repositories to be updated with patched
+BOS reporter, CMS test, and Cray CLI RPMs.
+If so, the script runs as if --include-rpms had been specified.
+If not, the script runs as if --no-rpms had been specified.
+
+To run the script noninteractively, specify one of the following
+mutually exclusive flags:
+
+--include-rpms  Patch the BOS, CFS, and PCS services.
+                Recreate the following Nexus repos to include the updated RPMs:
+                $REPO_LIST
+
+--no-rpms       Only patch the BOS, CFS, and PCS services.
+                Do not add the updated RPMs to Nexus.
+
+--rpms-only     Do not patch the BOS, CFS, and PCS services.
+                (The relevant charts and images will also not be uploaded
+                to Nexus)
+                Recreate the following Nexus repos to include the updated RPMS:
+                $REPO_LIST
+
+EOF
+}
+
+# Defaults:
+patch_services=Y
+patch_rpms=""
+
+if [[ $# -gt 1 ]]; then
+    usage
+    echo "ERROR: Too many arguments specified" >&2
+    exit 2
+elif [[ $# -eq 1 ]]; then
+    case "$1" in
+        "--include-rpms")
+            patch_services=Y
+            patch_rpms=Y
+            ;;
+        "--no-rpms")
+            patch_services=Y
+            patch_rpms=N
+            ;;
+        "--rpms-only")
+            patch_services=N
+            patch_rpms=Y
+            ;;
+        *)
+            usage
+            echo "ERROR: Unrecognized flag: '$1'" >&2
+            exit 2
+            ;;
+    esac
+fi
+
+if [[ -z ${patch_rpms} ]]; then
+    cat << EOF
+This hotfix includes updated Cray CLI and BOS reporter RPMs. In order to add them to Nexus, the following repos must be destroyed and
+recreated to include the additional content: $REPO_LIST
+
+This is irreversible.
+EOF
+    read -r -p "Include RPM updates in the patch? [y/n]:" response
+    case "$response" in
+        [yY][eE][sS]|[yY])
+            echo "Nexus will be updated to include the patched RPMs"
+            patch_rpms=Y
+            ;;
+        [nN][oO]|[nN])
+            echo "Nexus will NOT be updated to include the patched RPMs"
+            patch_rpms=N
+            ;;
+        *)
+            echo "Unrecognized response" >&2
+            exit 2
+            ;;
+    esac
+fi
+
+source "${ROOTDIR}/lib/version.sh"
+
+if [[ ${patch_services} == Y ]]; then
+    # Create scratch space
+    workdir="$(mktemp -d)"
+    trap "rm -fr '${workdir}'" EXIT
+
+    # Build manifest
+    # The PCS and CFS updates include fixes that BOS needs, which is why we do those updates first.
+    cat > "${workdir}/manifest.yaml" << EOF
+apiVersion: manifests/v1beta1
+metadata:
+  name: csm-1.5-bos-cfs-scale-hotfix
+spec:
+  charts:
+  - name: cray-power-control
+    version: 2.0.9
+    namespace: services
+    timeout: 20m
+  - name: cray-cfs-api
+    version: 1.18.6
+    namespace: services
+  - name: cray-bos
+    version: 2.10.24
+    namespace: services
+    timeout: 10m
+EOF
+
+    # Extract customizations.yaml
+    kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > "${workdir}/customizations.yaml"
+
+    # manifestgen
+    manifestgen -c "${workdir}/customizations.yaml" -i "${workdir}/manifest.yaml" -o "${workdir}/deploy-hotfix.yaml"
+fi
+
+# Export these variables for use by the setup-nexus script
+export patch_services
+export patch_rpms
+
+# Load artifacts into nexus
+"${ROOTDIR}/lib/setup-nexus.sh"
+
+if [[ ${patch_services} == Y ]]; then
+    # Deploy chart
+    loftsman ship --manifest-path "${workdir}/deploy-hotfix.yaml" --charts-path "${ROOTDIR}/helm"
+fi
+
+set +x
+cat >&2 <<EOF
++ Hotfix installed
+${0##*/}: OK
+EOF

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/install.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/install.sh
@@ -1,0 +1,1 @@
+../../../vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/install.sh

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/setup-nexus.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/setup-nexus.sh
@@ -1,0 +1,1 @@
+../../../csm-1.4/CASMCMS-9044-bos-cfs-scale/lib/setup-nexus.sh

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="1"}"}"
+
+# return if sourced
+return 0 2>/dev/null
+
+# otherwise print release information
+if [[ $# -eq 0 ]]; then
+    echo "$RELEASE"
+else
+    case "$1" in
+    -n|--name) echo "$RELEASE_NAME" ;;
+    -v|--version) echo "$RELEASE_VERSION" ;;
+    *)
+        echo >&2 "error: unsupported argumented: $1"
+        echo >&2 "usage: ${0##*/} [--name|--version]"
+        ;;
+    esac
+fi

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/nexus-repositories.template.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/nexus-repositories.template.yaml
@@ -1,0 +1,24 @@
+---
+cleanup: null
+type: hosted
+format: raw
+yum:
+  repodataDepth: 0
+  deployPolicy: STRICT
+name: $repository
+online: true
+storage:
+  blobStoreName: default
+  strictContentTypeValidation: false
+  writePolicy: ALLOW_ONCE
+---
+name: $group
+format: raw
+storage:
+  blobStoreName: csm
+  strictContentTypeValidation: false
+type: group
+online: true
+group:
+  memberNames:
+    - $repository

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/rpm/csm-noos/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/rpm/csm-noos/index.yaml
@@ -1,0 +1,6 @@
+https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos:
+  rpms:
+    - bos-reporter-2.10.24-1.noarch
+    - cray-cmstools-crayctldeploy-1.16.4-1.x86_64
+    - craycli-0.82.17-1.aarch64
+    - craycli-0.82.17-1.x86_64


### PR DESCRIPTION
Basically the CSM 1.5 version of https://github.com/Cray-HPE/csm-hotfixes/pull/50

However, the exact contents are different, of course. 

I partially tested it on mug and wasp, but fully tested it on groot.