### PR TITLE
CASMTRIAGE-7166: Add hotfix for tapms tenant status

### DIFF
--- a/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/README.md
+++ b/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/README.md
@@ -1,0 +1,19 @@
+# CASMTRIAGE-7166 - Fix for the status field in tenant deployments
+
+Fixes an issue with TAPMS where it will try to add nodes to the tenants HSM node group more than once, causing the tenant to get stuck in a "deploying" state.
+
+## Prerequisites
+
+- CSM versions 1.5.0 to 1.5.2
+
+## JIRA(s)
+
+This hotfix covers the following JIRA(s):
+
+* [CASMTRIAGE-7166](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7166)
+
+## Usage
+
+```bash
+./install-hotfix.sh
+```

--- a/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/docker/index.yaml
+++ b/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/docker/index.yaml
@@ -1,0 +1,7 @@
+---
+artifactory.algol60.net/csm-docker/stable:
+  tls-verify: true
+  images:
+    cray-tapms-operator:
+    - v0.3.0-2
+

--- a/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/helm/index.yaml
+++ b/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/helm/index.yaml
@@ -1,0 +1,7 @@
+---
+https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
+  charts:
+    cray-tapms-crd:
+    - 0.3.0-2
+    cray-tapms-operator:
+    - 0.3.0-2

--- a/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/install-hotfix.sh
+++ b/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/install-hotfix.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${ROOTDIR}/lib/version.sh"
+
+# Create scratch space
+workdir="$(mktemp -d)"
+trap "rm -fr '${workdir}'" EXIT
+
+# Build manifest
+cat > "${workdir}/manifest.yaml" << EOF
+apiVersion: manifests/v1beta1
+metadata:
+  name: casmtriage-7166
+spec:
+  sources:
+    charts:
+    - name: nexus
+      type: repo
+      location: https://packages.local/repository/charts
+  charts:
+  - name: cray-tapms-crd
+    source: nexus
+    version: 0.3.0-2
+    namespace: tapms-operator
+  - name: cray-tapms-operator
+    source: nexus
+    version: 0.3.0-2
+    namespace: tapms-operator
+EOF
+
+# Extract customizations.yaml
+kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > "${workdir}/customizations.yaml"
+
+# manifestgen
+manifestgen -c "${workdir}/customizations.yaml" -i "${workdir}/manifest.yaml" -o "${workdir}/deploy-hotfix.yaml"
+
+# Load artifacts into nexus
+${ROOTDIR}/lib/setup-nexus.sh
+
+# Deploy chart
+loftsman ship --manifest-path "${workdir}/deploy-hotfix.yaml"
+
+set +x
+cat >&2 <<EOF
++ Hotfix installed
+${0##*/}: OK
+EOF

--- a/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/lib/install.sh
+++ b/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/lib/install.sh
@@ -1,0 +1,1 @@
+../../../vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/install.sh

--- a/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/lib/setup-nexus.sh
+++ b/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/lib/setup-nexus.sh
@@ -1,0 +1,1 @@
+../../../csm-1.5/CASMINST-6896-gpg-keys/lib/setup-nexus.sh

--- a/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/lib/version.sh
+++ b/csm-1.5/CASMTRIAGE-7166-tapms-tenants-deploying/lib/version.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+: "${RELEASE:="${RELEASE_NAME:="csm-1.5-casmtriage-7166"}-${RELEASE_VERSION:="1"}"}"
+
+# return if sourced
+return 0 2>/dev/null
+
+# otherwise print release information
+if [[ $# -eq 0 ]]; then
+    echo "$RELEASE"
+else
+    case "$1" in
+    -n|--name) echo "$RELEASE_NAME" ;;
+    -v|--version) echo "$RELEASE_VERSION" ;;
+    *)
+        echo >&2 "error: unsupported argumented: $1"
+        echo >&2 "usage: ${0##*/} [--name|--version]"
+        ;;
+    esac
+fi


### PR DESCRIPTION
## Summary and Scope

Updates tapms to fix an issue that was preventing the status of tenants from getting to "deployed"

## Issues and Related PRs

* Resolves CASMTRIAGE-7166

## Testing

### Tested on:

  * Slice/Tyr

### Test description:

Most testing occured on Tyr, but the final hotfix patch test was deployed on Slice to validate it.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

