### PR TITLE
Update CSM 1.5 BOS hotfix to include fixes for bugs CASMCMS-9164 and CASMCMS-9143

### DIFF
--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
@@ -28,6 +28,8 @@ If applying this hotfix on CSM 1.5.2, it contains the following fixes and enhanc
         requests too large for other services to handle
       - The default value for this option should be sufficient to avoid this problem
     - CASMCMS-9039: Fix applystage action
+    - CASMCMS-9164: Fix runtime error in base operator bad path
+    - CASMCMS-9143: When validating boot sets, check all boot sets for severe errors before returning only warnings
 - CLI
   - Add support for new BOS v2 options described above
 - Tests
@@ -45,6 +47,8 @@ If applying this hotfix on CSM 1.5.1, it contains all of the fixes and enhanceme
   - v2
     - CASMCMS-8997: Improve logging
     - CASMCMS-8998: Optimize operator performance by bypassing unnecessary logic
+    - CASMCMS-9164: Fix runtime error in base operator bad path
+    - CASMCMS-9143: When validating boot sets, check all boot sets for severe errors before returning only warnings
 - CFS
   - CASMCMS-8978: Fix bugs causing failures for some component patch requests
 - PCS
@@ -70,6 +74,8 @@ If applying this hotfix on CSM 1.5.0, it contains all of the fixes and enhanceme
     - CASMCMS-8941: Break up large CFS component queries to avoid failures
     - CASMCMS-8916: BOS v2 components patch/put: Fix bug, validate inputs
     - CASMCMS-8905: Removed unintended ability to update v2 session fields other than status and components
+    - CASMCMS-9164: Fix runtime error in base operator bad path
+    - CASMCMS-9143: When validating boot sets, check all boot sets for severe errors before returning only warnings
   - v1
     - CASMCMS-8274: Gracefully handle CAPMC locked node error
 - CFS
@@ -141,8 +147,8 @@ These steps are not required, but until they are done, the updated RPMs will not
     updated BOS reporter RPM when it runs.
 
     For more information, see
-    - [Create an Image Management Customization CFS Session](https://github.com/Cray-HPE/docs-csm/blob/release/1.4/operations/configuration_management/Create_an_Image_Customization_CFS_Session.md]
-    - [Create UAN Boot Images](https://github.com/Cray-HPE/docs-csm/blob/release/1.4/operations/image_management/Create_UAN_Boot_Images.md)
+    - [Create an Image Management Customization CFS Session](https://github.com/Cray-HPE/docs-csm/blob/release/1.5/operations/configuration_management/Create_an_Image_Customization_CFS_Session.md]
+    - [Create UAN Boot Images](https://github.com/Cray-HPE/docs-csm/blob/release/1.5/operations/image_management/Create_UAN_Boot_Images.md)
 
 ## Rollback
 

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
@@ -3,9 +3,9 @@ artifactory.algol60.net/csm-docker/stable:
   tls-verify: true
   images:
     cray-boa:
-    - 1.4.4
+    - 1.4.5
     cray-bos:
-    - 2.10.24
+    - 2.10.27
     cray-cfs:
     - 1.18.6
     cray-power-control:

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
@@ -2,7 +2,7 @@
 https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
   charts:
     cray-bos:
-    - 2.10.24
+    - 2.10.27
     cray-cfs-api:
     - 1.18.6
     cray-power-control:

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="1"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="2"}"}"
 
 # return if sourced
 return 0 2>/dev/null

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/rpm/csm-noos/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/rpm/csm-noos/index.yaml
@@ -1,6 +1,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos:
   rpms:
-    - bos-reporter-2.10.24-1.noarch
+    - bos-reporter-2.10.27-1.noarch
     - cray-cmstools-crayctldeploy-1.16.4-1.x86_64
     - craycli-0.82.17-1.aarch64
     - craycli-0.82.17-1.x86_64


### PR DESCRIPTION
This updates the CSM 1.5 BOS scale hotfix to pull in fixes for two BOS bugs: [CASMCMS-9143](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9143) and [CASMCMS-9164](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9164). The former bug was fixed a while ago but wasn't significant enough to respin this hotfix, since it had no performance implications. However, the latter bug does impact BOS performance, and is probably more likely to be encountered at scale.