### PR TITLE
Update CSM 1.5 BOS hotfix to include CASMCMS-9162 and CASMCMS-9165

### DIFF
--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
@@ -17,6 +17,11 @@ If applying this hotfix on CSM 1.5.2, it contains the following fixes and enhanc
 
 - BOS
   - v2
+    - CASMCMS-9162: Add cfs_read_timeout option
+      - This option is at 10 seconds by default. This is the same value that was used before this became an option that could be set.
+      - This value should be raised higher when BOS requests to CFS are timing out.
+    - CASMCMS-9165: Fix per-bootset CFS option
+      - Without this fix, a CFS configuration set at the boot set level is ignored.
     - CASMCMS-9067: Add session_limit_required option
       - This option is disabled by default. If enabled, BOS v2 sessions cannot be created without specifying a limit
       - This can be used to avoid accidentally creating sessions with no limits specified, if desired

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
@@ -5,7 +5,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-boa:
     - 1.4.5
     cray-bos:
-    - 2.10.27
+    - 2.10.28
     cray-cfs:
     - 1.18.6
     cray-power-control:

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
@@ -2,7 +2,7 @@
 https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
   charts:
     cray-bos:
-    - 2.10.27
+    - 2.10.28
     cray-cfs-api:
     - 1.18.6
     cray-power-control:

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="2"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="3"}"}"
 
 # return if sourced
 return 0 2>/dev/null

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/rpm/csm-noos/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/rpm/csm-noos/index.yaml
@@ -1,6 +1,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos:
   rpms:
-    - bos-reporter-2.10.27-1.noarch
+    - bos-reporter-2.10.28-1.noarch
     - cray-cmstools-crayctldeploy-1.16.4-1.x86_64
     - craycli-0.82.17-1.aarch64
     - craycli-0.82.17-1.x86_64


### PR DESCRIPTION
This updates the CSM 1.5 BOS scale hotfix to pull in a BOS bug fix ([CASMCMS-9165](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9165)) and a BOS enhancement ([CASMCMS-9162](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9162)).

The enhancement is of particular usefulness for large scale systems. The bug fix is of general usefulness, not specifically large scale, but the same BOS version pulls in both of these.