### PR TITLE
Update CSM 1.4 BOS hotfix to include CASMCMS-9162 and CASMCMS-9165

### DIFF
--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/README.md
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/README.md
@@ -18,6 +18,12 @@ If applying this hotfix on CSM 1.4.3 or 1.4.4, it contains the following fixes a
       - Prevents a race condition that can cause some BOS operations to fail soon after full system bringup
     - CASMTRIAGE-6993: Improve BOS server resiliency and prevent OOM kill issues
   - v2
+    - CASMCMS-9162: Add cfs_read_timeout option
+      - This option is at 10 seconds by default. This is the same value that was used before this became an option that could be set.
+      - This value should be raised higher when BOS requests to CFS are timing out.
+    - CASMCMS-9165: Fix per-bootset CFS option
+      - Without this fix, a CFS configuration set at the boot set level is ignored.
+    - CASMCMS-9143: Fix bug in validate session template endpoint that caused severe errors to be overlooked in some cases.
     - CASMCMS-9067: Add session_limit_required option
       - This option is disabled by default. If enabled, BOS v2 sessions cannot be created without specifying a limit
       - This can be used to avoid accidentally creating sessions with no limits specified, if desired

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/docker/index.yaml
@@ -5,9 +5,9 @@ artifactory.algol60.net/csm-docker/stable:
     cfs-hwsync-agent:
     - 1.9.3
     cray-boa:
-    - 1.3.7
+    - 1.3.8
     cray-bos:
-    - 2.0.44
+    - 2.0.47
     cray-cfs:
     - 1.12.9
     docker.io/library/redis:

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/helm/index.yaml
@@ -4,6 +4,6 @@ https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
     cfs-hwsync-agent:
     - 1.9.3
     cray-bos:
-    - 2.0.44
+    - 2.0.47
     cray-cfs-api:
     - 1.12.9

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/lib/version.sh
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/lib/version.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-: "${RELEASE:="${RELEASE_NAME:="csm-1.4-bos-cfs-scale"}-${RELEASE_VERSION:="1"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.4-bos-cfs-scale"}-${RELEASE_VERSION:="2"}"}"
 
 # return if sourced
 return 0 2>/dev/null

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp2-compute/index.yaml
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp2-compute/index.yaml
@@ -1,4 +1,4 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2:
   rpms:
-    - bos-reporter-2.0.44-1.x86_64
-    - craycli-0.74.3-1.x86_64
+    - bos-reporter-2.0.47-1.x86_64
+    - craycli-0.74.4-1.x86_64

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp3-compute/index.yaml
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp3-compute/index.yaml
@@ -1,4 +1,4 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3:
   rpms:
-    - bos-reporter-2.0.44-1.x86_64
-    - craycli-0.74.3-1.x86_64
+    - bos-reporter-2.0.47-1.x86_64
+    - craycli-0.74.4-1.x86_64

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp4-compute/index.yaml
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp4-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4:
   rpms:
-    - bos-reporter-2.0.44-1.x86_64
+    - bos-reporter-2.0.47-1.x86_64

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp4/index.yaml
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp4/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4:
   rpms:
-    - bos-reporter-2.0.44-1.x86_64
+    - bos-reporter-2.0.47-1.x86_64


### PR DESCRIPTION
Same as https://github.com/Cray-HPE/csm-hotfixes/pull/58, but for CSM 1.4

This one also pulls in the fix for BOS bug [CASMCMS-9143](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9143)