### PR TITLE
CASMINST-7033: Create 1.5.{1,2} hotfix for `update-mgmt-ncn-cfs-config.sh`

### DIFF
--- a/csm-1.5/CASMINST-7033-update-mgmt-ncn-cfs-config/README.md
+++ b/csm-1.5/CASMINST-7033-update-mgmt-ncn-cfs-config/README.md
@@ -1,0 +1,65 @@
+# CASMINST-7033: CFS configuration data loss when running `update-mgmt-ncn-cfs-config.sh`
+
+## Affected CSM versions
+
+This hotfix addresses a problem that occurs only during the following scenarios:
+
+* Upgrade of a CSM 1.5.0 system to CSM 1.5.1 or 1.5.2
+* Upgrade of a CSM 1.5.1 system to CSM 1.5.2
+
+Note that even if the hotfix has already been applied during an upgrade from CSM 1.5.0 to 1.5.1, it
+is still required when upgrading from CSM 1.5.1 to 1.5.2. This is because it affects a script
+included in the CSM 1.5.1 and 1.5.2 release distributions.
+
+This hotfix does not apply to fresh installs of CSM 1.5.1 or 1.5.2, and it does not apply for
+upgrades from CSM 1.4.z to CSM 1.5.z. Those procedures use different instructions, which are not
+affected by this problem. However, no problems will occur if this hotfix is applied in those
+situations.
+
+## Problem description
+
+The instructions for installing the CSM 1.5.1 and 1.5.2 patches include a step that runs the script
+`update-mgmt-ncn-cfs-config.sh`. This script finds the CFS configuration applied to the management
+nodes and updates the CSM layers of that configuration to include the latest content from the CSM
+patch. If the CFS configuration contains the `additional_inventory` property or if any layers
+contain the `special_parameters.ims_require_dkms` property, that information is lost in the modified
+configuration.
+
+See the following JIRAs for more information:
+
+* [CASMINST-7033](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7033)
+* [CAST-36034](https://jira-pro.it.hpe.com:8443/browse/CAST-36034)
+* [CRAYSAT-1840](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1840)
+* [CRAYSAT-1842](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1842)
+* [CRAYSAT-1862](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1862)
+
+## Hotfix details
+
+This hotfix will replace the version of the `cfs-config-util` Docker image with a fixed version.
+This Docker image is used by the `update-mgmt-ncn-cfs-config.sh` script.
+
+## Installation instructions
+
+This hotfix should be installed during the process of upgrading from a CSM 1.5 release to CSM
+1.5.1 or 1.5.2. Specifically, it must be installed prior to running the procedure in [Update
+management node CFS configuration](https://github.com/Cray-HPE/docs-csm/blob/release/1.5/upgrade/1.5.2/README.md#update-management-node-cfs-configuration).
+
+1. (`ncn-m001`) Set `CSM_DISTDIR` to be the root of the extracted CSM 1.5.1 or 1.5.2 release
+   distribution tar file. For example:
+
+   ```
+   export CSM_DISTDIR="/etc/cray/upgrade/csm/csm-1.5.2"
+   ```
+
+1. (`ncn-m001`) Execute `install-hotfix.sh` to install the hotfix into the extracted CSM 1.5.1 or
+   1.5.2 release:
+
+    ```bash
+    ./install-hotfix.sh -c "$CSM_DISTDIR"
+    ```
+
+1. Return to the patch installation instructions for the patch being installed:
+   
+   * CSM 1.5.1: [Update management node CFS configuration](https://github.com/Cray-HPE/docs-csm/blob/release/1.5/upgrade/1.5.1/README.md#update-management-node-cfs-configuration)
+   * CSM 1.5.2: [Update management node CFS configuration](https://github.com/Cray-HPE/docs-csm/blob/release/1.5/upgrade/1.5.2/README.md#update-management-node-cfs-configuration)
+

--- a/csm-1.5/CASMINST-7033-update-mgmt-ncn-cfs-config/install-hotfix.sh
+++ b/csm-1.5/CASMINST-7033-update-mgmt-ncn-cfs-config/install-hotfix.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+#  MIT License
+#
+#  (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+set -eo pipefail
+ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${ROOT_DIR}/lib/install.sh"
+source "${ROOT_DIR}/lib/version.sh"
+
+function usage {
+
+  cat << EOF
+usage:
+
+./install-hotfix.sh [-v] [-c CSM_DISTDIR]
+
+Flags:
+
+-c              The location of the extracted CSM release distribution
+-v              Enable verbose output (run with set -x).
+
+Environment Variables:
+CSM_DISTDIR        The root of the extracted CSM release distribution
+EOF
+}
+
+CSM_DISTDIR="${CSM_DISTDIR:-}"
+while getopts ":vc:" o; do
+  case "${o}" in
+    c)
+      CSM_DISTDIR="${OPTARG}"
+      ;;
+    v)
+      set -x
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ -z "$CSM_DISTDIR" ]; then
+    echo >&2 "CSM_DISTDIR was not set! Aborting."
+    exit 1
+fi
+
+CFS_CONFIG_UTIL_REL_PATH="vendor/cfs-config-util.tar"
+NEW_CFS_CONFIG_UTIL_PATH="${ROOT_DIR}/${CFS_CONFIG_UTIL_REL_PATH}"
+OLD_CFS_CONFIG_UTIL_PATH="${CSM_DISTDIR}/${CFS_CONFIG_UTIL_REL_PATH}"
+
+echo "Backing up ${OLD_CFS_CONFIG_UTIL_PATH} to ${OLD_CFS_CONFIG_UTIL_PATH}.old"
+mv "${OLD_CFS_CONFIG_UTIL_PATH}" "${OLD_CFS_CONFIG_UTIL_PATH}.old"
+
+echo "Copying fixed cfs-config-util image from ${NEW_CFS_CONFIG_UTIL_PATH} to ${OLD_CFS_CONFIG_UTIL_PATH}"
+cp "${NEW_CFS_CONFIG_UTIL_PATH}" "${OLD_CFS_CONFIG_UTIL_PATH}"
+
+cat >&2 <<EOF
++ Hotfix installed
+${0##*/}: OK
+EOF

--- a/csm-1.5/CASMINST-7033-update-mgmt-ncn-cfs-config/lib/install.sh
+++ b/csm-1.5/CASMINST-7033-update-mgmt-ncn-cfs-config/lib/install.sh
@@ -1,0 +1,1 @@
+../../../vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/install.sh

--- a/csm-1.5/CASMINST-7033-update-mgmt-ncn-cfs-config/lib/version.sh
+++ b/csm-1.5/CASMINST-7033-update-mgmt-ncn-cfs-config/lib/version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+#  MIT License
+#
+#  (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a
+#  copy of this software and associated documentation files (the "Software"),
+#  to deal in the Software without restriction, including without limitation
+#  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+#  and/or sell copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included
+#  in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+#  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+#  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+#  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+: "${RELEASE:="${RELEASE_NAME:="CASMINST-7033-update-mgmt-ncn-cfs-config"}-${RELEASE_VERSION:="1"}"}"
+
+# return if sourced
+return 0 2>/dev/null
+
+# otherwise print release information
+if [[ $# -eq 0 ]]; then
+    echo "$RELEASE"
+else
+    case "$1" in
+    -n|--name) echo "$RELEASE_NAME" ;;
+    -v|--version) echo "$RELEASE_VERSION" ;;
+    *)
+        echo >&2 "error: unsupported argumented: $1"
+        echo >&2 "usage: ${0##*/} [--name|--version]"
+        ;;
+    esac
+fi

--- a/release.sh
+++ b/release.sh
@@ -40,7 +40,7 @@ export PACKAGING_TOOLS_IMAGE=${PACKAGING_TOOLS_IMAGE:-artifactory.algol60.net/ds
 export RPM_TOOLS_IMAGE=${RPM_TOOLS_IMAGE:-artifactory.algol60.net/dst-docker-mirror/internal-docker-stable-local/rpm-tools:1.0.0}
 export SKOPEO_IMAGE=${SKOPEO_IMAGE:-artifactory.algol60.net/dst-docker-mirror/quay-remote/skopeo/stable:v1.13.2}
 export CRAY_NEXUS_SETUP_IMAGE=${CRAY_NEXUS_SETUP_IMAGE:-artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.1}
-export CFS_CONFIG_UTIL_IMAGE=${CFS_CONFIG_UTIL_IMAGE:-arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cfs-config-util:5.0.0}
+export CFS_CONFIG_UTIL_IMAGE=${CFS_CONFIG_UTIL_IMAGE:-arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cfs-config-util:5.1.1}
 
 # code to store credentials in environment variable
 if [ ! -z "$ARTIFACTORY_USER" ] && [ ! -z "$ARTIFACTORY_TOKEN" ]; then


### PR DESCRIPTION
## Summary and Scope

Create a hotfix for CSM 1.5.1 and 1.5.2 to address the issue with the `update-mgmt-ncn-cfs-config.sh` script dropping the `additional_inventory` and `special_paremeters` in the CFS configuration assigned to management nodes.

## Issues and Related PRs

* Resolves [CASMINST-7033](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7033)
* Merge this PR before the docs-csm PR: https://github.com/Cray-HPE/docs-csm/pull/5498

## Testing

### Tested on:

  * drax

### Test description:

* Copied the relevant portions of a CSM 1.5.2 release distribution that existed on drax to another directory. Relevant portions include the `update-mgmt-ncn-cfs-config.sh` script, the shell libraries in `lib/`, and the file `vendor/cfs-config-util.tar`.
* Built the hotfix tar file and copied to drax. Extracted it there.
* Followed the instructions in the `README.md` file in the hotfix directory to install the hotfix into the partial 1.5.2 directory.
* Ran `update-mgmt-ncn-cfs-config.sh -h` in the now modified 1.5.2 directory and verified it was using the correct newer version of the `cfs-config-util.tar` image. This was evident from the presence of the `--cfs-version` option.

## Risks and Mitigations

Low risk. This is an important fix to prevent data loss in CFS configurations.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
