### PR TITLE
Correct version numbers in BOS scaling hotfix install scripts

### DIFF
--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/install-hotfix.sh
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/install-hotfix.sh
@@ -140,7 +140,7 @@ spec:
     version: 1.9.3
     namespace: services
   - name: cray-bos
-    version: 2.0.44
+    version: 2.0.47
     namespace: services
     timeout: 10m
 EOF

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/lib/version.sh
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/lib/version.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-: "${RELEASE:="${RELEASE_NAME:="csm-1.4-bos-cfs-scale"}-${RELEASE_VERSION:="2"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.4-bos-cfs-scale"}-${RELEASE_VERSION:="3"}"}"
 
 # return if sourced
 return 0 2>/dev/null

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
@@ -140,7 +140,7 @@ spec:
     version: 1.18.6
     namespace: services
   - name: cray-bos
-    version: 2.10.24
+    version: 2.10.28
     namespace: services
     timeout: 10m
 EOF

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="3"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="4"}"}"
 
 # return if sourced
 return 0 2>/dev/null


### PR DESCRIPTION
In my previous PRs, I failed to update the version numbers in the BOS scaling hotfix install scripts. This corrects that.