### PR TITLE
Update Cray CLI version in BOS hotfix

### DIFF
--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="4"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="5"}"}"
 
 # return if sourced
 return 0 2>/dev/null

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/rpm/csm-noos/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/rpm/csm-noos/index.yaml
@@ -2,5 +2,5 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos:
   rpms:
     - bos-reporter-2.10.28-1.noarch
     - cray-cmstools-crayctldeploy-1.16.4-1.x86_64
-    - craycli-0.82.17-1.aarch64
-    - craycli-0.82.17-1.x86_64
+    - craycli-0.82.18-1.aarch64
+    - craycli-0.82.18-1.x86_64


### PR DESCRIPTION
The CSM 1.5 BOS hotfix needs a newer version of the Cray CLI.