### PR TITLE
Update BOS/CFS 1.5 scale fix

### DIFF
--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
@@ -35,6 +35,10 @@ If applying this hotfix on CSM 1.5.2, it contains the following fixes and enhanc
     - CASMCMS-9039: Fix applystage action
     - CASMCMS-9164: Fix runtime error in base operator bad path
     - CASMCMS-9143: When validating boot sets, check all boot sets for severe errors before returning only warnings
+- CFS
+  - CASMCMS-9196: Prevent failure when creating source without specifying authentication method
+  - CASMCMS-9197: Significantly improve speed of some queries on large scale systems
+  - CASMCMS-9198: Prevent invalid option values causing CFS to enter CrashLoopBackOff
 - CLI
   - Add support for new BOS v2 options described above
 - Tests

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
@@ -42,6 +42,8 @@ If applying this hotfix on CSM 1.5.2, it contains the following fixes and enhanc
   - CASMCMS-9200: Fix bug causing excessive redundant database and network activity
   - CASMCMS-9202: Add API action to enable restore of CFS v3 sources from backup
   - CASMCMS-9206: Fix bug preventing creation of v3 configurations if `additional_inventory` contains `source` field.
+  - CASMCMS-9210: Correctly check additional_inventory layers when determining if a source is in use
+  - CASMCMS-9211: Improve performance of configuration delete operation
 - CLI
   - Add support for new BOS v2 options described above
 - Tests

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
@@ -41,6 +41,7 @@ If applying this hotfix on CSM 1.5.2, it contains the following fixes and enhanc
   - CASMCMS-9198: Prevent invalid option values causing CFS to enter CrashLoopBackOff
   - CASMCMS-9200: Fix bug causing excessive redundant database and network activity
   - CASMCMS-9202: Add API action to enable restore of CFS v3 sources from backup
+  - CASMCMS-9206: Fix bug preventing creation of v3 configurations if `additional_inventory` contains `source` field.
 - CLI
   - Add support for new BOS v2 options described above
 - Tests

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
@@ -39,6 +39,8 @@ If applying this hotfix on CSM 1.5.2, it contains the following fixes and enhanc
   - CASMCMS-9196: Prevent failure when creating source without specifying authentication method
   - CASMCMS-9197: Significantly improve speed of some queries on large scale systems
   - CASMCMS-9198: Prevent invalid option values causing CFS to enter CrashLoopBackOff
+  - CASMCMS-9200: Fix bug causing excessive redundant database and network activity
+  - CASMCMS-9202: Add API action to enable restore of CFS v3 sources from backup
 - CLI
   - Add support for new BOS v2 options described above
 - Tests

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
@@ -7,7 +7,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-bos:
     - 2.10.28
     cray-cfs:
-    - 1.18.11
+    - 1.18.13
     cray-power-control:
     - 2.4.0
     cray-power-control-hmth-test:

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
@@ -7,7 +7,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-bos:
     - 2.10.28
     cray-cfs:
-    - 1.18.6
+    - 1.18.9
     cray-power-control:
     - 2.4.0
     cray-power-control-hmth-test:

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
@@ -7,7 +7,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-bos:
     - 2.10.28
     cray-cfs:
-    - 1.18.9
+    - 1.18.10
     cray-power-control:
     - 2.4.0
     cray-power-control-hmth-test:

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
@@ -7,7 +7,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-bos:
     - 2.10.28
     cray-cfs:
-    - 1.18.10
+    - 1.18.11
     cray-power-control:
     - 2.4.0
     cray-power-control-hmth-test:

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
@@ -7,7 +7,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-bos:
     - 2.10.28
     cray-cfs:
-    - 1.18.13
+    - 1.18.14
     cray-power-control:
     - 2.4.0
     cray-power-control-hmth-test:

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
@@ -4,6 +4,6 @@ https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
     cray-bos:
     - 2.10.28
     cray-cfs-api:
-    - 1.18.10
+    - 1.18.11
     cray-power-control:
     - 2.0.9

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
@@ -4,6 +4,6 @@ https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
     cray-bos:
     - 2.10.28
     cray-cfs-api:
-    - 1.18.6
+    - 1.18.9
     cray-power-control:
     - 2.0.9

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
@@ -4,6 +4,6 @@ https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
     cray-bos:
     - 2.10.28
     cray-cfs-api:
-    - 1.18.11
+    - 1.18.13
     cray-power-control:
     - 2.0.9

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
@@ -4,6 +4,6 @@ https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
     cray-bos:
     - 2.10.28
     cray-cfs-api:
-    - 1.18.13
+    - 1.18.14
     cray-power-control:
     - 2.0.9

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
@@ -4,6 +4,6 @@ https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
     cray-bos:
     - 2.10.28
     cray-cfs-api:
-    - 1.18.9
+    - 1.18.10
     cray-power-control:
     - 2.0.9

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
@@ -137,7 +137,7 @@ spec:
     namespace: services
     timeout: 20m
   - name: cray-cfs-api
-    version: 1.18.9
+    version: 1.18.10
     namespace: services
   - name: cray-bos
     version: 2.10.28

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
@@ -137,7 +137,7 @@ spec:
     namespace: services
     timeout: 20m
   - name: cray-cfs-api
-    version: 1.18.13
+    version: 1.18.14
     namespace: services
   - name: cray-bos
     version: 2.10.28

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
@@ -137,7 +137,7 @@ spec:
     namespace: services
     timeout: 20m
   - name: cray-cfs-api
-    version: 1.18.10
+    version: 1.18.11
     namespace: services
   - name: cray-bos
     version: 2.10.28

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
@@ -137,7 +137,7 @@ spec:
     namespace: services
     timeout: 20m
   - name: cray-cfs-api
-    version: 1.18.6
+    version: 1.18.9
     namespace: services
   - name: cray-bos
     version: 2.10.28

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
@@ -137,7 +137,7 @@ spec:
     namespace: services
     timeout: 20m
   - name: cray-cfs-api
-    version: 1.18.11
+    version: 1.18.13
     namespace: services
   - name: cray-bos
     version: 2.10.28

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="5"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="6"}"}"
 
 # return if sourced
 return 0 2>/dev/null


### PR DESCRIPTION
Update the CSM 1.5 BOS/CFS scale hotfix with the following fixes/improvements:

* [CASMCMS-9196](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9196) - Fix CFS Exception when trying to create Source
* [CASMCMS-9197](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9197) - Bypass needless work in some CFS queries
* [CASMCMS-9198](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9198) - Prevent invalid option values from causing CFS CLBO
* [CASMCMS-9200](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9200) - Fix a thread safety bug and performance issue in CFS server
* [CASMCMS-9202](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9202) - Add CFS v3 API option to enable restoring Source data from backup
* [CASMCMS-9206](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9206) - Fix bug preventing creation of V3 configurations if their additional inventory layer specifies the source field.
* [CASMCMS-9210](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9210): Correctly check additional_inventory layers when seeing if a source is in use
* [CASMCMS-9211](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9211): Improve performance of configuration delete operation

CASMCMS-9197, CASMCMS-9200, and CASMCMS-9211 are especially important for scale systems -- CASMCMS-9197 reduces some queries from taking over 1 minute to taking under 1 second. CASMCMS-9211 reduces the time for some delete operations by more than 2/3. The problem documented in CASMCMS-9200 is likely to have a larger impact on scale systems.