### PR TITLE
CASMTRIAGE-7526 - fix for CASMCMS-9175 hotfix install script.

### DIFF
--- a/csm-1.5/CASMCMS-9175-console-inotify-tools/install-hotfix.sh
+++ b/csm-1.5/CASMCMS-9175-console-inotify-tools/install-hotfix.sh
@@ -62,7 +62,9 @@ kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yam
 # manifestgen
 manifestgen -c "${workdir}/customizations.yaml" -i "${workdir}/manifest.yaml" -o "${workdir}/deploy-hotfix.yaml"
 
-# Load artifacts into nexus
+# Load artifacts into nexus - k8s services only
+export patch_services=Y
+export patch_rpms=N
 ${ROOTDIR}/lib/setup-nexus.sh
 
 # Deploy chart

--- a/csm-1.5/CASMCMS-9175-console-inotify-tools/lib/version.sh
+++ b/csm-1.5/CASMCMS-9175-console-inotify-tools/lib/version.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-: "${RELEASE:="${RELEASE_NAME:="csm-1.5-casmcms-9175"}-${RELEASE_VERSION:="1"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.5-casmcms-9175"}-${RELEASE_VERSION:="2"}"}"
 
 # return if sourced
 return 0 2>/dev/null


### PR DESCRIPTION
## Summary and Scope

There was a bug in the install script for the hotfix `CASMCMS-9175-console-inotify-tools` which prevented it from installing correctly. This resolves the issue and correctly uploads the new artifacts into nexus.

## Issues and Related PRs

* Resolves [CASMTRIAGE-7526](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7526)

## Testing
### Tested on:
  * `Hela`

### Test description:

I hand-applied the script change to the hotfix install directory on Hela and successfully executed the script.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Low risk - fixing install script.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

