### PR TITLE
CASMCMS-9219: Fix bug causing CFS server CLBO

### DIFF
--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
@@ -7,7 +7,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-bos:
     - 2.10.28
     cray-cfs:
-    - 1.18.14
+    - 1.18.15
     cray-power-control:
     - 2.4.0
     cray-power-control-hmth-test:

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
@@ -4,6 +4,6 @@ https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
     cray-bos:
     - 2.10.28
     cray-cfs-api:
-    - 1.18.14
+    - 1.18.15
     cray-power-control:
     - 2.0.9

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
@@ -137,7 +137,7 @@ spec:
     namespace: services
     timeout: 20m
   - name: cray-cfs-api
-    version: 1.18.14
+    version: 1.18.15
     namespace: services
   - name: cray-bos
     version: 2.10.28

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="6"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="7"}"}"
 
 # return if sourced
 return 0 2>/dev/null


### PR DESCRIPTION
This updates the BOS/CFS scale hotfix to pull in a bugfix. The bug causes the CFS server to not start because it is stuck in CLBO. I am not listing the bugfix in the hotfix readme, because the bug was introduced in the previous iteration of the hotfix -- it is not present in CSM itself otherwise.

The problem is not present in the CSM 1.4 version of this hotfix.

I have tested this updated hotfix on hela (the system where the problem was reported) and verified that it resolves the issue.