### PR TITLE
Update CSM 1.5 BOS/CFS/PCS scale hotfix to include fix for CASMHMS-6299

### DIFF
--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
@@ -44,6 +44,8 @@ If applying this hotfix on CSM 1.5.2, it contains the following fixes and enhanc
   - CASMCMS-9206: Fix bug preventing creation of v3 configurations if `additional_inventory` contains `source` field.
   - CASMCMS-9210: Correctly check additional_inventory layers when determining if a source is in use
   - CASMCMS-9211: Improve performance of configuration delete operation
+- PCS
+  - CASMHMS-6299: Fix resource leaks and scaling issues
 - CLI
   - Add support for new BOS v2 options described above
 - Tests

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
@@ -9,9 +9,9 @@ artifactory.algol60.net/csm-docker/stable:
     cray-cfs:
     - 1.18.15
     cray-power-control:
-    - 2.4.0
+    - 2.6.0
     cray-power-control-hmth-test:
-    - 2.4.0
+    - 2.6.0
     docker.io/library/redis:
     - 5.0-alpine
     - 5.0-alpine3.12

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
@@ -6,4 +6,4 @@ https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
     cray-cfs-api:
     - 1.18.15
     cray-power-control:
-    - 2.0.9
+    - 2.0.11

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
@@ -133,7 +133,7 @@ metadata:
 spec:
   charts:
   - name: cray-power-control
-    version: 2.0.9
+    version: 2.0.11
     namespace: services
     timeout: 20m
   - name: cray-cfs-api

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="7"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="8"}"}"
 
 # return if sourced
 return 0 2>/dev/null


### PR DESCRIPTION
The resource issues seen in PCS are particularly important to address on large scale systems. The BOS/CFS scale hotfix already includes an updated version of PCS in it, to pull in other fixes. This PR updates the hotfix to pull in these additional PCS fixes.

If the PCS fixes will also be of interest to non-scale customers, then probably a standalone hotfix for it should also be created.