### PR TITLE
CASMCMS-9242: Pull in latest BOS scale fixes/improvements

### DIFF
--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/README.md
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/README.md
@@ -18,9 +18,10 @@ If applying this hotfix on CSM 1.4.3 or 1.4.4, it contains the following fixes a
       - Prevents a race condition that can cause some BOS operations to fail soon after full system bringup
     - CASMTRIAGE-6993: Improve BOS server resiliency and prevent OOM kill issues
   - v2
-    - CASMCMS-9162: Add cfs_read_timeout option
-      - This option is at 10 seconds by default. This is the same value that was used before this became an option that could be set.
-      - This value should be raised higher when BOS requests to CFS are timing out.
+    - CASMCMS-9225: Improve performance of large GET components requests
+    - CASMCMS-9162/CASMCMS-9242: Add BOS options: bss_read_timeout, capmc_read_timeout, cfs_read_timeout, hsm_read_timeout
+      - These options are each at 10 seconds by default. This is the same value that was used before this became an option that could be set.
+      - This value should be raised higher when BOS requests to the particular service are timing out.
     - CASMCMS-9165: Fix per-bootset CFS option
       - Without this fix, a CFS configuration set at the boot set level is ignored.
     - CASMCMS-9143: Fix bug in validate session template endpoint that caused severe errors to be overlooked in some cases.

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/docker/index.yaml
@@ -7,7 +7,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-boa:
     - 1.3.8
     cray-bos:
-    - 2.0.47
+    - 2.0.50
     cray-cfs:
     - 1.12.9
     docker.io/library/redis:

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/helm/index.yaml
@@ -4,6 +4,6 @@ https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
     cfs-hwsync-agent:
     - 1.9.3
     cray-bos:
-    - 2.0.47
+    - 2.0.50
     cray-cfs-api:
     - 1.12.9

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/install-hotfix.sh
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/install-hotfix.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -140,7 +140,7 @@ spec:
     version: 1.9.3
     namespace: services
   - name: cray-bos
-    version: 2.0.47
+    version: 2.0.50
     namespace: services
     timeout: 10m
 EOF

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/lib/version.sh
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/lib/version.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-: "${RELEASE:="${RELEASE_NAME:="csm-1.4-bos-cfs-scale"}-${RELEASE_VERSION:="3"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.4-bos-cfs-scale"}-${RELEASE_VERSION:="4"}"}"
 
 # return if sourced
 return 0 2>/dev/null

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp2-compute/index.yaml
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp2-compute/index.yaml
@@ -1,4 +1,4 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2:
   rpms:
-    - bos-reporter-2.0.47-1.x86_64
-    - craycli-0.74.4-1.x86_64
+    - bos-reporter-2.0.50-1.x86_64
+    - craycli-0.74.5-1.x86_64

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp3-compute/index.yaml
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp3-compute/index.yaml
@@ -1,4 +1,4 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3:
   rpms:
-    - bos-reporter-2.0.47-1.x86_64
-    - craycli-0.74.4-1.x86_64
+    - bos-reporter-2.0.50-1.x86_64
+    - craycli-0.74.5-1.x86_64

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp4-compute/index.yaml
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp4-compute/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4:
   rpms:
-    - bos-reporter-2.0.47-1.x86_64
+    - bos-reporter-2.0.50-1.x86_64

--- a/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp4/index.yaml
+++ b/csm-1.4/CASMCMS-9044-bos-cfs-scale/rpm/csm-sle-15sp4/index.yaml
@@ -1,3 +1,3 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4:
   rpms:
-    - bos-reporter-2.0.47-1.x86_64
+    - bos-reporter-2.0.50-1.x86_64

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/README.md
@@ -17,9 +17,10 @@ If applying this hotfix on CSM 1.5.2, it contains the following fixes and enhanc
 
 - BOS
   - v2
-    - CASMCMS-9162: Add cfs_read_timeout option
-      - This option is at 10 seconds by default. This is the same value that was used before this became an option that could be set.
-      - This value should be raised higher when BOS requests to CFS are timing out.
+    - CASMCMS-9225: Improve performance of large GET components requests
+    - CASMCMS-9162/CASMCMS-9242: Add BOS options: bss_read_timeout, cfs_read_timeout, hsm_read_timeout, pcs_read_timeout
+      - These options are each at 10 seconds by default. This is the same value that was used before this became an option that could be set.
+      - This value should be raised higher when BOS requests to the particular service are timing out.
     - CASMCMS-9165: Fix per-bootset CFS option
       - Without this fix, a CFS configuration set at the boot set level is ignored.
     - CASMCMS-9067: Add session_limit_required option

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/docker/index.yaml
@@ -5,7 +5,7 @@ artifactory.algol60.net/csm-docker/stable:
     cray-boa:
     - 1.4.5
     cray-bos:
-    - 2.10.28
+    - 2.10.31
     cray-cfs:
     - 1.18.15
     cray-power-control:

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/helm/index.yaml
@@ -2,7 +2,7 @@
 https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
   charts:
     cray-bos:
-    - 2.10.28
+    - 2.10.31
     cray-cfs-api:
     - 1.18.15
     cray-power-control:

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/install-hotfix.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -140,7 +140,7 @@ spec:
     version: 1.18.15
     namespace: services
   - name: cray-bos
-    version: 2.10.28
+    version: 2.10.31
     namespace: services
     timeout: 10m
 EOF

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/lib/version.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="8"}"}"
+: "${RELEASE:="${RELEASE_NAME:="csm-1.5-bos-cfs-scale"}-${RELEASE_VERSION:="9"}"}"
 
 # return if sourced
 return 0 2>/dev/null

--- a/csm-1.5/CASMCMS-9097-bos-cfs-scale/rpm/csm-noos/index.yaml
+++ b/csm-1.5/CASMCMS-9097-bos-cfs-scale/rpm/csm-noos/index.yaml
@@ -1,6 +1,6 @@
 https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos:
   rpms:
-    - bos-reporter-2.10.28-1.noarch
+    - bos-reporter-2.10.31-1.noarch
     - cray-cmstools-crayctldeploy-1.16.4-1.x86_64
-    - craycli-0.82.18-1.aarch64
-    - craycli-0.82.18-1.x86_64
+    - craycli-0.82.19-1.aarch64
+    - craycli-0.82.19-1.x86_64


### PR DESCRIPTION
This updates the BOS 1.4 and 1.5 hotfixes to pull in the latest fixes and improvements. UKMet is waiting on this.