### PR TITLE
CASMNET-2366 cray-dns-unbound-manager should not remove records if Kea response is empty

### DIFF
--- a/hotfix/CASMNET-2366-cray-dns-unbound/README.md
+++ b/hotfix/CASMNET-2366-cray-dns-unbound/README.md
@@ -1,0 +1,29 @@
+# CASMNET-2366 - cray-dns-unbound-manager should not remove records if Kea response is empty
+
+## Problem Description
+
+Resolved an issue in cray-dns-unbound-manager where the active configuration could be unnecessarily updated. 
+The hotfix ensures that the active configuration remains unchanged if the Kea API returns an empty response and the number of generated records is fewer than those already present.
+
+## Prerequisites
+
+- CSM version 1.7.0
+  - Fixed in CSM 1.7.1
+
+## Installation
+
+The `install-hotfix.sh` script may be run on any Master or Worker Non-Compute Node.
+
+Example:
+
+```bash
+./install-hotfix.sh
+```
+
+## Rollback
+
+To revert `cray-dns-unbound` to the previous version:
+
+```bash
+helm -n services rollback cray-dns-unbound
+```

--- a/hotfix/CASMNET-2366-cray-dns-unbound/docker/index.yaml
+++ b/hotfix/CASMNET-2366-cray-dns-unbound/docker/index.yaml
@@ -1,0 +1,5 @@
+artifactory.algol60.net/csm-docker/stable:
+  tls-verify: true
+  images:
+    cray-dns-unbound:
+    - 0.10.1

--- a/hotfix/CASMNET-2366-cray-dns-unbound/helm/index.yaml
+++ b/hotfix/CASMNET-2366-cray-dns-unbound/helm/index.yaml
@@ -1,0 +1,4 @@
+https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
+  charts:
+    cray-dns-unbound:
+    - 0.10.1

--- a/hotfix/CASMNET-2366-cray-dns-unbound/install-hotfix.sh
+++ b/hotfix/CASMNET-2366-cray-dns-unbound/install-hotfix.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${ROOTDIR}/lib/version.sh"
+
+# Create scratch space
+workdir="$(mktemp -d)"
+trap "rm -fr '${workdir}'" EXIT
+
+# Build manifest
+cat > "${workdir}/manifest.yaml" << EOF
+apiVersion: manifests/v1beta1
+metadata:
+  name: casmnet-2366
+spec:
+  sources:
+    charts:
+    - name: nexus
+      type: repo
+      location: https://packages.local/repository/charts
+  charts:
+  - name: cray-dns-unbound
+    version: 0.10.1
+    source: nexus
+    namespace: services
+EOF
+
+# Extract customizations.yaml
+kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' | base64 -d > "${workdir}/customizations.yaml"
+
+# Extract and update cray-precache-images
+kubectl -n loftsman get cm loftsman-platform -o jsonpath='{.data.manifest\.yaml}' | yq r - 'spec.charts(name==cray-precache-images)' > "${workdir}/precache.yaml"
+yq w -i "${workdir}/precache.yaml" 'values.cacheImages[+]' "artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1"
+yq w -i "${workdir}/precache.yaml" 'source' "nexus"
+yq w -i "${workdir}/manifest.yaml" 'spec.charts[+]' -f "${workdir}/precache.yaml"
+
+# manifestgen
+manifestgen -c "${workdir}/customizations.yaml" -i "${workdir}/manifest.yaml" -o "${workdir}/deploy-hotfix.yaml"
+
+# Load artifacts into nexus
+${ROOTDIR}/lib/setup-nexus.sh
+
+# Deploy chart
+loftsman ship --manifest-path "${workdir}/deploy-hotfix.yaml"
+
+set +x
+cat >&2 <<EOF
++ Hotfix installed
+${0##*/}: OK
+EOF

--- a/hotfix/CASMNET-2366-cray-dns-unbound/lib/install.sh
+++ b/hotfix/CASMNET-2366-cray-dns-unbound/lib/install.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+
+# Copyright 2020,2022 Hewlett Packard Enterprise Development LP
+
+# Defaults
+: "${NEXUS_URL:="https://packages.local"}"
+: "${NEXUS_REGISTRY:="registry.local"}"
+
+export NEXUS_URL
+
+# Set ROOTDIR to reasonable default, assumes this script is in a subdir (e.g., lib)
+: "${ROOTDIR:="$(dirname "${BASH_SOURCE[0]}")/.."}"
+
+declare -a podman_run_flags=(--network host)
+
+# Prefer to use podman, but for environments with docker
+if [[ "${USE_DOCKER_NOT_PODMAN:-"no"}" == "yes" ]]; then
+    echo >&2 "warning: using docker, not podman"
+    shopt -s expand_aliases
+    alias podman=docker
+fi
+
+function requires() {
+    while [[ $# -gt 0 ]]; do
+        command -v "$1" >/dev/null 2>&1 || {
+            echo >&2 "command not found: ${1}"
+            exit 1
+        }
+        shift
+    done
+}
+
+requires curl find podman realpath
+
+# usage: load-vendor-image TARFILE
+#
+# Loads a vendored container image TARFILE saved using "docker save" into
+# podman's runtime to facilitate installation.
+function load-vendor-image() {
+    (
+        set -o pipefail
+        podman load -q -i "$1" 2>/dev/null | sed -e 's/^.*: //'
+    )
+}
+
+declare -a vendor_images=()
+
+# usage: load-install-deps
+#
+# Loads vendored images into podman's image storage to facilitate installation.
+# Product install scripts should call this function before using any functions
+# which use CRAY_NEXUS_SETUP_IMAGE or SKOPEO_IMAGE to interact with Nexus.
+#
+# Product install scripts should call `clean-install-deps` when finished to
+# remove images loaded into podman.
+function load-install-deps() {
+    # Load vendor images to support installation
+    if [[ -f "${ROOTDIR}/vendor/cray-nexus-setup.tar" ]]; then
+        [[ -v CRAY_NEXUS_SETUP_IMAGE ]] || CRAY_NEXUS_SETUP_IMAGE="$(load-vendor-image "${ROOTDIR}/vendor/cray-nexus-setup.tar")" || return
+        vendor_images+=("$CRAY_NEXUS_SETUP_IMAGE")
+    fi
+
+    if [[ -f "${ROOTDIR}/vendor/skopeo.tar" ]]; then
+        [[ -v SKOPEO_IMAGE ]] || SKOPEO_IMAGE="$(load-vendor-image "${ROOTDIR}/vendor/skopeo.tar")" || return
+        vendor_images+=("$SKOPEO_IMAGE")
+    fi
+
+    if [[ -f "${ROOTDIR}/vendor/rpm-tools.tar" ]]; then
+        [[ -v RPM_TOOLS_IMAGE ]] || RPM_TOOLS_IMAGE="$(load-vendor-image "${ROOTDIR}/vendor/rpm-tools.tar")" || return
+        vendor_images+=("$RPM_TOOLS_IMAGE")
+    fi
+}
+
+# usage: load-cfs-config-util
+#
+# Loads the vendored cfs-config-util container image TARFILE into podman's
+# image storage to facilitate updating CFS configurations.
+#
+# A script that uses the `cfs-config-util` functions in this file should call
+# this function first and should call `clean-install-deps` at the end to remove
+# images loaded into podman.
+function load-cfs-config-util() {
+    if [[ -f "${ROOTDIR}/vendor/cfs-config-util.tar" ]]; then
+        [[ -v CFS_CONFIG_UTIL_IMAGE ]] || CFS_CONFIG_UTIL_IMAGE="$(load-vendor-image "${ROOTDIR}/vendor/cfs-config-util.tar")" || return
+        vendor_images+=("$CFS_CONFIG_UTIL_IMAGE")
+    fi
+}
+
+# usage: clean-install-deps
+#
+# Removes images from podman's image storage which have been loaded by the
+# `load-install-deps` or `load-cfs-config-util` functions.
+#
+# Should be called at the end of product install scripts.
+function clean-install-deps() {
+    # Clean images used to support installation
+    for image in "${vendor_images[@]}"; do
+        podman rmi -f "$image"
+    done
+}
+
+# usage: nexus-get-credential [[-n NAMESPACE] SECRET]
+#
+# Gets Nexus username and password from SECRET in NAMESPACE and sets
+# NEXUS_USERNAME and NEXUS_PASSWORD as appropriate. By default NAMESPACE is
+# "nexus" and SECRET is "nexus-admin-credential".
+function nexus-get-credential() {
+    requires base64 kubectl
+
+    [[ $# -gt 0 ]] || set -- -n nexus nexus-admin-credential
+
+    kubectl get secret "${@}" >/dev/null || return $?
+
+    export NEXUS_USERNAME="$(kubectl get secret "${@}" -o jsonpath='{.data.username}' | base64 -d)"
+    export NEXUS_PASSWORD="$(kubectl get secret "${@}" -o jsonpath='{.data.password}' | base64 -d)"
+}
+
+# usage: nexus-setdefault-credential
+#
+# Ensures NEXUS_USERNAME and NEXUS_PASSWORD are set, at least to default
+# credential.
+function nexus-setdefault-credential() {
+    [[ -v NEXUS_PASSWORD && -n "$NEXUS_PASSWORD" ]] && return 0
+    if ! nexus-get-credential; then
+        echo >&2 "warning: Nexus admin credential not detected, falling back to defaults"
+        export NEXUS_USERNAME="admin"
+        export NEXUS_PASSWORD="admin123"
+    fi
+    return 0
+}
+
+# usage: nexus-setup (blobstores|repositories) CONFIG
+#
+# Sets up Nexus blob stores or repositories given CONFIG, a valid configuration
+# YAML file where each document is valid HTTP POST data to the respective Nexus
+# REST API:
+#
+# - Blob stores: /service/rest/beta/blobstores/<type>[/<name>]
+# - Repositories: /service/rest/beta/repositories/<format>/<type>[/<name>]
+#
+# Requires the following environment variables to be set:
+#
+#   NEXUS_URL - Base Nexus URL; defaults to https://packages.local
+#   CRAY_NEXUS_SETUP_IMAGE - Image containing Cray's Nexus setup tools;
+#       recommended to vendor with tag specific to a product version
+#
+# If the NEXUS_PASSWORD environment variable is not set, attempts to set
+# NEXUS_USERNAME and NEXUS_PASSWORD based on the nexus-admin-credential
+# Kubernetes secret. Otherwise, the default Nexus admin credentials are used.
+function nexus-setup() {
+    nexus-setdefault-credential
+    podman run --rm "${podman_run_flags[@]}" \
+        -v "$(realpath "$2"):/config.yaml:ro" \
+        -e NEXUS_URL \
+        -e NEXUS_USERNAME \
+        -e NEXUS_PASSWORD \
+        "$CRAY_NEXUS_SETUP_IMAGE" \
+        "nexus-${1}-create" /config.yaml
+}
+
+# usage: nexus-wait-for-rpm-repomd REPOSITORY [INTERVAL=5]
+#
+# Waits for RPM repository metadata to exist for given REPOSITORY.
+#
+# Nexus automatically computes RPM repository metadata for yum repositories.
+# Immediately trying to upload RPMs to a yum repository may fail until Nexus
+# generates the initial repository metadata. This function checks for
+# repodata/repomd.xml to exist from the repository's root path before
+# returning. It sleeps INTERVAL seconds (default: 5) in between checks.
+#
+# Requires the following environment variables to be set:
+#
+#   NEXUS_URL - Base Nexus URL; defaults to https://packages.local
+#
+# If the NEXUS_PASSWORD environment variable is not set, attempts to set
+# NEXUS_USERNAME and NEXUS_PASSWORD based on the nexus-admin-credential
+# Kubernetes secret. Otherwise, the default Nexus admin credentials are used.
+function nexus-wait-for-rpm-repomd() {
+    nexus-setdefault-credential
+    podman run --rm "${podman_run_flags[@]}" \
+        -e NEXUS_URL \
+        -e NEXUS_USERNAME \
+        -e NEXUS_PASSWORD \
+        "$CRAY_NEXUS_SETUP_IMAGE" \
+        "nexus-wait-for-rpm-repomd" "${@}"
+}
+
+# usage: nexus-upload (helm|raw|yum) DIRECTORY REPOSITORY
+#
+# Uploads a DIRECTORY of assets to the specified Nexus REPOSITORY.
+#
+# The REPOSITORY must be of the specified format (i.e., helm, raw, yum) else
+# the upload may not succeed or select the proper files under the given
+# DIRECTORY.
+#
+# Requires the following environment variables to be set:
+#
+#   NEXUS_URL - Base Nexus URL; defaults to https://packages.local
+#   CRAY_NEXUS_SETUP_IMAGE - Image containing Cray's Nexus setup tools;
+#       recommended to vendor with tag specific to a product version
+#
+# If the NEXUS_PASSWORD environment variable is not set, attempts to set
+# NEXUS_USERNAME and NEXUS_PASSWORD based on the nexus-admin-credential
+# Kubernetes secret. Otherwise, the default Nexus admin credentials are used.
+function nexus-upload() {
+    local repotype="$1"
+    local src="$2"
+    local reponame="$3"
+
+    [[ -d "$src" ]] || return 0
+
+    nexus-setdefault-credential
+    podman run --rm "${podman_run_flags[@]}" \
+        -v "$(realpath "$src"):/data:ro" \
+        -e NEXUS_URL \
+        -e NEXUS_USERNAME \
+        -e NEXUS_PASSWORD \
+        "$CRAY_NEXUS_SETUP_IMAGE" \
+        "nexus-upload-repo-${repotype}" "/data/" "$reponame"
+}
+
+# usage: skopeo-sync DIRECTORY
+#
+# Uploads a DIRECTORY of container images to the Nexus registry.
+#
+# Requires the following environment variables to be set:
+#
+#   NEXUS_REGISTRY - Hostname of Nexus registry; defaults to registry.local
+#   SKOPEO_IMAGE - Image containing Skopeo tool; recommended to vendor with tag
+#       specific to a product version
+#
+# If the NEXUS_PASSWORD environment variable is not set, attempts to set
+# NEXUS_USERNAME and NEXUS_PASSWORD based on the nexus-admin-credential
+# Kubernetes secret. Otherwise, the default Nexus admin credentials are used.
+function skopeo-sync() {
+    local src="$1"
+
+    [[ -d "$src" ]] || return 0
+
+    nexus-setdefault-credential
+    # Note: Have to default NEXUS_USERNAME below since
+    # nexus-setdefault-credential returns immediately if NEXUS_PASSWORD is set.
+    podman run --rm "${podman_run_flags[@]}" \
+        -v "$(realpath "$src"):/image:ro" \
+        "$SKOPEO_IMAGE" \
+        sync --scoped --src dir --dest docker \
+        --dest-creds "${NEXUS_USERNAME:-admin}:${NEXUS_PASSWORD}" \
+        --dest-tls-verify=false \
+        /image "$NEXUS_REGISTRY"
+}
+
+# usage: skopeo-copy SOURCE DESTINATION
+#
+# Uses skopeo copy to copy an image within the registry.
+#
+# Requires the following environment variables to be set:
+#
+#   NEXUS_REGISTRY - Hostname of Nexus registry; defaults to registry.local
+#   SKOPEO_IMAGE - Image containing Skopeo tool; recommended to vendor with tag
+#       specific to a product version
+#
+# If the NEXUS_PASSWORD environment variable is not set, attempts to set
+# NEXUS_USERNAME and NEXUS_PASSWORD based on the nexus-admin-credential
+# Kubernetes secret. Otherwise, the default Nexus admin credentials are used.
+function skopeo-copy() {
+    local src="$1"
+    local dest="$2"
+
+    if [[ -z "$src" || -z "$dest" ]]; then
+        echo >&2 "usage: skopeo-copy SOURCE DESTINATION"
+        return 1
+    fi
+
+    nexus-setdefault-credential
+    # Note: Have to default NEXUS_USERNAME below since
+    # nexus-setdefault-credential returns immediately if NEXUS_PASSWORD is set.
+    podman run --rm "${podman_run_flags[@]}" \
+        "$SKOPEO_IMAGE" \
+        copy \
+        --src-tls-verify=false \
+        --dest-tls-verify=false \
+        --src-creds "${NEXUS_USERNAME:-admin}:${NEXUS_PASSWORD}" \
+        --dest-creds "${NEXUS_USERNAME:-admin}:${NEXUS_PASSWORD}" \
+        "docker://${NEXUS_REGISTRY}/${src}" \
+        "docker://${NEXUS_REGISTRY}/${dest}"
+}
+
+# usage: cfs-config-util-options-help
+#
+# Outputs information about the passthrough options accepted by the
+# cfs-config-util container image. These are options which can be specified by
+# the admin calling the installation script in the product which are then
+# passed through directly to the cfs-config-util container entrypoint.
+#
+function cfs-config-util-options-help() {
+    podman run --rm --name cfs-config-util-options-help --entrypoint=passthrough-options-help \
+        "${CFS_CONFIG_UTIL_IMAGE}"
+}
+
+# usage: cfs-config-util-process-opts [options]
+#
+# Pre-processes the options being passed to cfs-config-util. This finds any
+# options which require local file access and determines the appropriate mount
+# options needed when calling `podman`. It also then modifies any file paths in
+# the cfs-config-util options to point at the locations where those files will
+# be mounted inside the container.
+#
+# Outputs a JSON object with the following keys:
+#
+#   mount_options:      A string containing the mount options that should be
+#                       passed to `podman`.
+#   translated_args:    The cfs-config-util options with any file paths
+#                       translated appropriately.
+#
+function cfs-config-util-process-opts() {
+    podman run --rm --name cfs-config-util-process-opts --entrypoint=process-file-options \
+        "${CFS_CONFIG_UTIL_IMAGE}" "$@"
+}
+
+# usage: cfs-config-util [options]
+#
+# Run the cfs-config-util container under podman. Run this function with `-h`
+# to see the full usage information for the options understood by this utility.
+#
+# All arguments passed to this function are passed through to the underlying
+# cfs-config-util container's main entry point.
+#
+# Returns:
+#   0 if successful
+#   1 if the call to cfs-config-util to update the CFS configurations failed
+#   2 if the options passed to cfs-config-util could not be parsed
+#
+function cfs-config-util() {
+    local err_temp_file="$(mktemp /tmp/cfs-config-util-process-opts-err-XXXXX)"
+    local out_temp_file="$(mktemp /tmp/cfs-config-util-process-opts-out-XXXXX)"
+    cfs-config-util-process-opts "$@" 1>"${out_temp_file}" 2>"${err_temp_file}"
+    local rc=$?
+
+    if [[ $rc -ne 0 ]]; then
+        # The name of the script calling this function is $0
+        local script_name="$(basename "$0")"
+        # Substitute the name of the script in the usage info error message
+        sed -e "s/process-file-options/${script_name}/" < $err_temp_file
+        rm $err_temp_file $out_temp_file
+        return 2
+    fi
+
+    local podman_cli_args="--mount type=bind,src=/etc/kubernetes/admin.conf,target=$HOME/.kube/config,ro=true"
+    podman_cli_args+=" --mount type=bind,src=/etc/pki/trust/anchors,target=/usr/local/share/ca-certificates,ro=true"
+    podman_cli_args+=" $(jq -r '.mount_opts' < "$out_temp_file")"
+
+    local translated_args="$(jq -r '.translated_args' < "$out_temp_file")"
+    rm $err_temp_file $out_temp_file
+
+    if ! podman run --rm --name cfs-config-util $podman_cli_args "${CFS_CONFIG_UTIL_IMAGE}" ${translated_args}; then
+        return 1
+    fi
+}
+
+# usage: createrepo DIRECTORY
+#
+# Creates an RPM repository from RPMs under the specified DIRECTORY.
+#
+# Useful when using rpm-sync to copy RPMs from various upstream repositories
+# to a single directory.
+function createrepo() {
+    local repodir="$1"
+
+    if [[ ! -d "$repodir" ]]; then
+        echo >&2 "error: no such directory: ${repodir}"
+        return 1
+    fi
+
+    podman run --rm "${podman_run_flags[@]}" \
+        ${DOCKER_NETWORK:+"--network=${DOCKER_NETWORK}"} \
+        -v "$(realpath "$repodir"):/data" \
+        "$RPM_TOOLS_IMAGE" \
+        createrepo --verbose /data
+}

--- a/hotfix/CASMNET-2366-cray-dns-unbound/lib/setup-nexus.sh
+++ b/hotfix/CASMNET-2366-cray-dns-unbound/lib/setup-nexus.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -exo pipefail
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")/.."
+source "${ROOTDIR}/lib/install.sh"
+
+load-install-deps
+
+# Upload assets to existing repositories
+skopeo-sync "${ROOTDIR}/docker"
+nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
+
+clean-install-deps
+
+set +x
+cat >&2 <<EOF
++ Nexus setup complete
+setup-nexus.sh: OK
+EOF

--- a/hotfix/CASMNET-2366-cray-dns-unbound/lib/version.sh
+++ b/hotfix/CASMNET-2366-cray-dns-unbound/lib/version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+: "${RELEASE:="${RELEASE_NAME:="CASMNET-2366"}-${RELEASE_VERSION:="1.7.0-20250905"}"}"
+
+# return if sourced
+return 0 2>/dev/null
+
+# otherwise print release information
+if [[ $# -eq 0 ]]; then
+    echo "$RELEASE"
+else
+    case "$1" in
+    -n|--name) echo "$RELEASE_NAME" ;;
+    -v|--version) echo "$RELEASE_VERSION" ;;
+    *)
+        echo >&2 "error: unsupported argument: $1"
+        echo >&2 "usage: ${0##*/} [--name|--version]"
+        ;;
+    esac
+fi

--- a/release.sh
+++ b/release.sh
@@ -38,7 +38,7 @@ ROOTDIR="$(dirname "${BASH_SOURCE[0]}")"
 # Override tools images
 export PACKAGING_TOOLS_IMAGE=${PACKAGING_TOOLS_IMAGE:-artifactory.algol60.net/dst-docker-mirror/internal-docker-stable-local/packaging-tools:0.14.0}
 export RPM_TOOLS_IMAGE=${RPM_TOOLS_IMAGE:-artifactory.algol60.net/dst-docker-mirror/internal-docker-stable-local/rpm-tools:1.0.0}
-export SKOPEO_IMAGE=${SKOPEO_IMAGE:-artifactory.algol60.net/dst-docker-mirror/quay-remote/skopeo/stable:v1.13.2}
+export SKOPEO_IMAGE=${SKOPEO_IMAGE:-artifactory.algol60.net/csm-docker/stable/quay.io/skopeo/stable:v1}
 export CRAY_NEXUS_SETUP_IMAGE=${CRAY_NEXUS_SETUP_IMAGE:-artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1}
 export CFS_CONFIG_UTIL_IMAGE=${CFS_CONFIG_UTIL_IMAGE:-arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cfs-config-util:5.1.1}
 

--- a/release.sh
+++ b/release.sh
@@ -39,7 +39,7 @@ ROOTDIR="$(dirname "${BASH_SOURCE[0]}")"
 export PACKAGING_TOOLS_IMAGE=${PACKAGING_TOOLS_IMAGE:-artifactory.algol60.net/dst-docker-mirror/internal-docker-stable-local/packaging-tools:0.14.0}
 export RPM_TOOLS_IMAGE=${RPM_TOOLS_IMAGE:-artifactory.algol60.net/dst-docker-mirror/internal-docker-stable-local/rpm-tools:1.0.0}
 export SKOPEO_IMAGE=${SKOPEO_IMAGE:-artifactory.algol60.net/dst-docker-mirror/quay-remote/skopeo/stable:v1.13.2}
-export CRAY_NEXUS_SETUP_IMAGE=${CRAY_NEXUS_SETUP_IMAGE:-artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.7.1}
+export CRAY_NEXUS_SETUP_IMAGE=${CRAY_NEXUS_SETUP_IMAGE:-artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.11.1}
 export CFS_CONFIG_UTIL_IMAGE=${CFS_CONFIG_UTIL_IMAGE:-arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cfs-config-util:5.1.1}
 
 # code to store credentials in environment variable


### PR DESCRIPTION
## Summary and Scope

It's possible for `cray-dns-unbound-manager` to get a response from the Kea API that contains no reservation data.

When this occurs `cray-dns-unbound-manager` continues processing which can result in records being deleted.

```
2025-08-28 11:54:15,647 - __main__ - ERROR - Kea API returned successfully, but with no leases.
2025-08-28 11:54:15,647 - __main__ - ERROR -     return code: 1
2025-08-28 11:54:15,647 - __main__ - ERROR -     return data: [{'result': 1, 'text': 'unable to forward command to the dhcp4 service: No such file or directory. The server is likely to be offline'}]
---
2025-08-28 11:54:17,284 - __main__ - INFO - Number of new records (including duplicates) 14431
```
The next run that occurs when Kea is working properly restores the records.
```
2025-08-28 11:56:39,447 - __main__ - INFO - Retrieved Kea data 26s
2025-08-28 11:56:39,448 - __main__ - INFO - Found 213 leases and reservations in Kea globals
2025-08-28 11:56:39,448 - __main__ - INFO - Found 87 subnets in Kea
2025-08-28 11:56:39,454 - __main__ - INFO - Found 8954 leases and reservations in Kea local subnets 0s
2025-08-28 11:56:42,338 - __main__ - INFO - Gathered 8954 total leases and reservations local and global 2s
---
2025-08-28 11:57:36,179 - __main__ - INFO - Number of existing records 14431
2025-08-28 11:57:36,179 - __main__ - INFO - Number of new records (including duplicates) 56206
```
This behaviour is undesirable as loss of access to hardware components can occur until DNS rights itself.

This PR changes the behaviour of `cray-dns-unbound-manager` such that if the response from Kea is empty and fewer records were generated than already exist, the DNS configuration is left untouched.

## Issues and Related PRs

* Resolves [CASMNET-2366](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2366)

## Testing

* Code fix has been tested on `wasp` and `baldar` see https://github.com/Cray-HPE/csm-hotfixes/pull/75 for test details.
* The installation of the CSM 1.7 hotfix was tested on `mug`.

### Tested on:

  * `mug`

### Test description:

Verified hotfix installed correctly on `mug`. It was necessary to update the version of cray-nexus-setup and skopeo in order to have image signatures correctly processed.

```
ncn-m001:~/cspiller/hotfix/CASMNET-2366-1.7.0-20250905 # ./install-hotfix.sh
++ dirname ./install-hotfix.sh
+ ROOTDIR=.
+ source ./lib/version.sh
++ : CASMNET-2366-1.7.0-20250905
++ return 0
++ mktemp -d
+ workdir=/tmp/tmp.rmc4tV5J1X
+ trap 'rm -fr '\''/tmp/tmp.rmc4tV5J1X'\''' EXIT
+ cat
+ kubectl -n loftsman get secret site-init -o 'jsonpath={.data.customizations\.yaml}'
+ base64 -d
+ kubectl -n loftsman get cm loftsman-platform -o 'jsonpath={.data.manifest\.yaml}'
+ yq r - 'spec.charts(name==cray-precache-images)'
+ yq w -i /tmp/tmp.rmc4tV5J1X/precache.yaml 'values.cacheImages[+]' artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1
+ yq w -i /tmp/tmp.rmc4tV5J1X/precache.yaml source nexus
+ yq w -i /tmp/tmp.rmc4tV5J1X/manifest.yaml 'spec.charts[+]' -f /tmp/tmp.rmc4tV5J1X/precache.yaml
+ manifestgen -c /tmp/tmp.rmc4tV5J1X/customizations.yaml -i /tmp/tmp.rmc4tV5J1X/manifest.yaml -o /tmp/tmp.rmc4tV5J1X/deploy-hotfix.yaml
+ ./lib/setup-nexus.sh
++ dirname ./lib/setup-nexus.sh
+ ROOTDIR=./lib/..
+ source ./lib/../lib/install.sh
++ : https://packages.local
++ : registry.local
++ export NEXUS_URL
++ : ./lib/..
++ podman_run_flags=(--network host)
++ declare -a podman_run_flags
++ [[ no == \y\e\s ]]
++ requires curl find podman realpath
++ [[ 4 -gt 0 ]]
++ command -v curl
++ shift
++ [[ 3 -gt 0 ]]
++ command -v find
++ shift
++ [[ 2 -gt 0 ]]
++ command -v podman
++ shift
++ [[ 1 -gt 0 ]]
++ command -v realpath
++ shift
++ [[ 0 -gt 0 ]]
++ vendor_images=()
++ declare -a vendor_images
+ load-install-deps
+ [[ -f ./lib/../vendor/cray-nexus-setup.tar ]]
+ [[ -v CRAY_NEXUS_SETUP_IMAGE ]]
++ load-vendor-image ./lib/../vendor/cray-nexus-setup.tar
++ set -o pipefail
++ podman load -q -i ./lib/../vendor/cray-nexus-setup.tar
++ sed -e 's/^.*: //'
+ CRAY_NEXUS_SETUP_IMAGE=docker.io/library/cray-nexus-setup:CASMNET-2366-1.7.0-20250905
+ vendor_images+=("$CRAY_NEXUS_SETUP_IMAGE")
+ [[ -f ./lib/../vendor/skopeo.tar ]]
+ [[ -v SKOPEO_IMAGE ]]
++ load-vendor-image ./lib/../vendor/skopeo.tar
++ set -o pipefail
++ podman load -q -i ./lib/../vendor/skopeo.tar
++ sed -e 's/^.*: //'
+ SKOPEO_IMAGE=docker.io/library/skopeo:CASMNET-2366-1.7.0-20250905
+ vendor_images+=("$SKOPEO_IMAGE")
+ [[ -f ./lib/../vendor/rpm-tools.tar ]]
+ skopeo-sync ./lib/../docker
+ local src=./lib/../docker
+ [[ -d ./lib/../docker ]]
+ nexus-setdefault-credential
+ [[ -v NEXUS_PASSWORD ]]
+ nexus-get-credential
+ requires base64 kubectl
+ [[ 2 -gt 0 ]]
+ command -v base64
+ shift
+ [[ 1 -gt 0 ]]
+ command -v kubectl
+ shift
+ [[ 0 -gt 0 ]]
+ [[ 0 -gt 0 ]]
+ set -- -n nexus nexus-admin-credential
+ kubectl get secret -n nexus nexus-admin-credential
++ kubectl get secret -n nexus nexus-admin-credential -o 'jsonpath={.data.username}'
++ base64 -d
+ export NEXUS_USERNAME=admin
+ NEXUS_USERNAME=admin
++ kubectl get secret -n nexus nexus-admin-credential -o 'jsonpath={.data.password}'
++ base64 -d
+ export NEXUS_PASSWORD=vMo2hO2bKOhD66HjUiCEX2BUwIKD1U0Bb70BF1EG94w=
+ NEXUS_PASSWORD=vMo2hO2bKOhD66HjUiCEX2BUwIKD1U0Bb70BF1EG94w=
+ return 0
++ realpath ./lib/../docker
+ podman run --rm --network host -v /root/cspiller/hotfix/CASMNET-2366-1.7.0-20250905/docker:/image:ro docker.io/library/skopeo:CASMNET-2366-1.7.0-20250905 sync --scoped --src dir --dest docker --dest-creds admin:vMo2hO2bKOhD66HjUiCEX2BUwIKD1U0Bb70BF1EG94w= --dest-tls-verify=false /image registry.local
time="2025-10-07T09:40:01Z" level=info msg="Copying image ref 1/1" from="dir:/image/artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1" to="docker://registry.local/artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1"
Getting image source signatures
Checking if image destination supports signatures
Copying blob sha256:9824c27679d3b27c5e1cb00a73adb6f4f8d556994111c12db3c5d61a0c843df8
Copying blob sha256:5e402166e58a0976e0fa2fe38776d2bd02eb288bd25ec2b4f1a8b11160473398
Copying blob sha256:cb820698f85dd5c4f765cd64b5181e30be4428dcbe01071e07dee11d3f331853
Copying blob sha256:97683023fafc53a4bba39bdeb87f4cfada88293caaeb51ab1a5b3266a6ab013a
Copying blob sha256:d067d9524bcccce99d0e1878f8e394e7480aa1cec4924ab43e7479535ac8ce09
Copying blob sha256:17ccfd3a2219dee3b50d9680f016ed1c7b780f815b22a858078b52ab7a5fa898
Copying blob sha256:c8c63760541a118de4f31ce1f3e956345c292beac88cd6f4c6e22c9314163623
Copying blob sha256:ab793ce55591b93c412860058f9cee860f09f5d5c0c2df06499b360b2d7ce68a
Copying blob sha256:4a42660d8101c6d13c8ef5ce04fb360f4f311487d07973bd079e497d971a52e0
Copying blob sha256:5374d52ca9e9bbe930864d536d9b66b0a77c88532b6894ed6f1658ee81a40a4d
Copying blob sha256:c64552959c0b68b79eb49ff83718ba8947d1708f44350542be1d01dfc5b71253
Copying blob sha256:50d1841aaa7b70dd17a1565d472dc368156d38e3493a66071e70d9c92d160f47
Copying blob sha256:dc08fcbced3b4097e613323fb95acd1fdd66b724f74eb9366dc423b7eaf90a2f
Copying blob sha256:b1b986e2bc3ef06b2bfd2fabfeba7788985e6f32445438f2f36bfba988ba3f2c
Copying blob sha256:64c8a323be23dc6ad14375ccaa6b5a39432a811cc15e87863cb31cec3f95496c
Copying blob sha256:dc1e98967d36fccb6ef752ace0bcd29a427d7c6072bf786b42cceb4981e4156e
Copying blob sha256:5b7159594d9b28b3db446afbf7239b598c6813be5eaeb07cd0401a0084abfb98
Copying blob sha256:4f5a39f16e4cecd22cde375f08099ef596c2ee245f7fafdf49002eb984f061ee
Copying blob sha256:66ea526a88aa6a87120f691aefc53c7036343a75b039c4fc5bf57fcc9b5f96fd
Copying config sha256:464857d5f4174a5785f606e325dbf3dc2e5f90d3550c202ee56dbf60194a054f
Writing manifest to image destination
Storing signatures
time="2025-10-07T09:40:02Z" level=info msg="Synced 1 images from 1 sources"
+ nexus-upload helm ./lib/../helm charts
+ local repotype=helm
+ local src=./lib/../helm
+ local reponame=charts
+ [[ -d ./lib/../helm ]]
+ nexus-setdefault-credential
+ [[ -v NEXUS_PASSWORD ]]
+ [[ -n vMo2hO2bKOhD66HjUiCEX2BUwIKD1U0Bb70BF1EG94w= ]]
+ return 0
++ realpath ./lib/../helm
+ podman run --rm --network host -v /root/cspiller/hotfix/CASMNET-2366-1.7.0-20250905/helm:/data:ro -e NEXUS_URL -e NEXUS_USERNAME -e NEXUS_PASSWORD docker.io/library/cray-nexus-setup:CASMNET-2366-1.7.0-20250905 nexus-upload-repo-helm /data/ charts
/data/cray-dns-unbound-0.10.1.tgz	DEBUG <curl to URL  https://packages.local/service/rest/v1/components?repository=charts> completed with: 400 19092 0.054041 353287
/data/cray-dns-unbound-0.10.1.tgz	INFO Repository charts already exists
real	0m 0.78s
user	0m 0.41s
sys	0m 0.40s
+ clean-install-deps
+ for image in "${vendor_images[@]}"
+ podman rmi -f docker.io/library/cray-nexus-setup:CASMNET-2366-1.7.0-20250905
Untagged: docker.io/library/cray-nexus-setup:CASMNET-2366-1.7.0-20250905
Deleted: 3e5620374772fd2a85f1cfc240f30773ce0169325722f22ec3d810cc50ffb3e7
+ for image in "${vendor_images[@]}"
+ podman rmi -f docker.io/library/skopeo:CASMNET-2366-1.7.0-20250905
Untagged: docker.io/library/skopeo:CASMNET-2366-1.7.0-20250905
Deleted: c67417f92975febef59ad130674539f08ca818cac3e25264e493c435f083de6c
+ set +x
+ Nexus setup complete
setup-nexus.sh: OK
+ loftsman ship --manifest-path /tmp/tmp.rmc4tV5J1X/deploy-hotfix.yaml
2025-10-07T09:40:05Z INF Initializing the connection to the Kubernetes cluster using KUBECONFIG (system default), and context (current-context) command=ship
2025-10-07T09:40:05Z INF Initializing helm client object command=ship
         |\
         | \
         |  \
         |___\      Shipping your Helm workloads with Loftsman
       \--||___/
  ~~~~~~\_____/~~~~~~~

2025-10-07T09:40:05Z INF Ensuring that the loftsman namespace exists command=ship
2025-10-07T09:40:05Z INF Running a release for the provided manifest at /tmp/tmp.rmc4tV5J1X/deploy-hotfix.yaml command=ship

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-dns-unbound v0.10.1
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2025-10-07T09:40:05Z INF Found value overrides for chart, applying:
domain_name: mug.hpc.amslabs.hpecorp.net
forwardZones:
- forwardIps:
  - 16.110.135.51
  name: .
 chart=cray-dns-unbound command=ship namespace=services version=0.10.1
2025-10-07T09:40:05Z INF Running helm install/upgrade with arguments: upgrade --install cray-dns-unbound https://packages.local/repository/charts/cray-dns-unbound-0.10.1.tgz --namespace services --create-namespace --set global.chart.name=cray-dns-unbound --set global.chart.version=0.10.1 -f /tmp/loftsman-1759830005/cray-dns-unbound-values.yaml chart=cray-dns-unbound command=ship namespace=services version=0.10.1
2025-10-07T09:41:15Z INF Release "cray-dns-unbound" has been upgraded. Happy Helming!
NAME: cray-dns-unbound
LAST DEPLOYED: Tue Oct  7 09:40:06 2025
NAMESPACE: services
STATUS: deployed
REVISION: 9
TEST SUITE: None
 chart=cray-dns-unbound command=ship namespace=services version=0.10.1

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Releasing cray-precache-images v0.6.0
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

2025-10-07T09:41:16Z INF Found value overrides for chart, applying:
cacheImages:
- artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-kube:2.8.1
- artifactory.algol60.net/csm-docker/stable/docker.io/weaveworks/weave-npc:2.8.1
- artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v3.9.3
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.9.3
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.26.15
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.26.15
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.26.15
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.26.15
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.9
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.1
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.29.15
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.29.15
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.29.15
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.29.15
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.9
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/coredns/coredns:v1.11.3
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-apiserver:v1.32.5
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-controller-manager:v1.32.5
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-scheduler:v1.32.5
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/kube-proxy:v1.32.5
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/pause:3.10
- artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
- artifactory.algol60.net/csm-docker/stable/istio/pilot:1.26.0-cray1-distroless
- artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyvernopre:v1.13.4
- artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno:v1.13.4
- artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/cleanup-controller:v1.13.4
- artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/reports-controller:v1.13.4
- artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/background-controller:v1.13.4
- artifactory.algol60.net/csm-docker/stable/ghcr.io/kyverno/kyverno-cli:v1.13.4
- artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/kubectl:1.33.1
- artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa:0.62.0-envoy-rootless
- artifactory.algol60.net/csm-docker/stable/cray-dhcp-kea:0.13.0
- artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.0
- artifactory.algol60.net/csm-docker/stable/cray-dns-powerdns:0.5.0
- artifactory.algol60.net/csm-docker/stable/cray-powerdns-manager:0.8.4
- artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
- artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.32.2
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-provisioner:v5.2.0
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-attacher:v4.8.1
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-snapshotter:v8.2.1
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
- artifactory.algol60.net/csm-docker/stable/registry.k8s.io/sig-storage/csi-resizer:v1.13.2
- artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi:v3.14.0
- artifactory.algol60.net/csm-docker/stable/docker.io/sonatype/nexus3:3.70.4
- artifactory.algol60.net/csm-docker/stable/cray-nexus-setup:0.12.2
- artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium:v1.16.5
- artifactory.algol60.net/csm-docker/stable/quay.io/cilium/cilium-envoy:v1.30.8
- artifactory.algol60.net/csm-docker/stable/quay.io/cilium/operator-generic:v1.16.5
- artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-relay:v1.16.5
- artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui:v0.13.2
- artifactory.algol60.net/csm-docker/stable/quay.io/cilium/hubble-ui-backend:v0.13.2
- artifactory.algol60.net/csm-docker/stable/cray-dns-unbound:0.10.1
cacheRefreshSeconds: "120"
 chart=cray-precache-images command=ship namespace=nexus version=0.6.0
2025-10-07T09:41:16Z INF Running helm install/upgrade with arguments: upgrade --install cray-precache-images https://packages.local/repository/charts/cray-precache-images-0.6.0.tgz --namespace nexus --create-namespace --set global.chart.name=cray-precache-images --set global.chart.version=0.6.0 --timeout 20m0s -f /tmp/loftsman-1759830005/cray-precache-images-values.yaml chart=cray-precache-images command=ship namespace=nexus version=0.6.0
2025-10-07T09:41:56Z INF Release "cray-precache-images" has been upgraded. Happy Helming!
NAME: cray-precache-images
LAST DEPLOYED: Tue Oct  7 09:41:16 2025
NAMESPACE: nexus
STATUS: deployed
REVISION: 6
TEST SUITE: None
 chart=cray-precache-images command=ship namespace=nexus version=0.6.0
2025-10-07T09:41:56Z INF Ship status: success. Recording status, manifest to configmap loftsman-casmnet-2366 in namespace loftsman command=ship
2025-10-07T09:41:56Z INF Recording log data to configmap loftsman-casmnet-2366-ship-log in namespace loftsman command=ship
+ set +x
+ Hotfix installed
install-hotfix.sh: OK

ncn-m001:~/cspiller/hotfix/CASMNET-2366-1.7.0-20250905 # helm -n services ls --filter unbound
NAME            	NAMESPACE	REVISION	UPDATED                                	STATUS  	CHART                  	APP VERSION
cray-dns-unbound	services 	9       	2025-10-07 09:40:06.238476792 +0000 UTC	deployed	cray-dns-unbound-0.10.1	0.10.1
```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable