### PR TITLE
CAST-39551: Prevent multiple Kubernetes jobs being created for the same CFS session

### DIFF
--- a/hotfix/CAST-39551/README.md
+++ b/hotfix/CAST-39551/README.md
@@ -1,0 +1,59 @@
+# CAST-39551 - Prevent duplicate Kubernetes jobs for CFS sessions
+
+## Problem description
+
+Resolved an issue where Kafka errors could result in multiple Kubernetes
+jobs being created for the same CFS session.
+
+## Hotfix description
+
+This hotfix modifies CFS and cfs-operator to prevent a second Kubernetes job
+from being created for a CFS session, if one has already been created.
+
+## Hotfix chart versions
+
+| *Chart*             | *Namespace* | *Version* |
+| `cray-cfs-api`      | `services`  | `1.23.7`  |
+| `cray-cfs-operator` | `services`  | `1.27.2`  |
+
+## Prerequisites
+
+- CSM versions 1.6.0 to 1.6.2
+
+## Installation
+
+The `install-hotfix.sh` script may be run on any Master or Worker Non-Compute Node.
+
+Example:
+
+```bash
+./install-hotfix.sh
+```
+
+## Rollback
+
+To revert to the previous versions:
+
+```bash
+function rollback-chart-cast-39551
+{
+    # Usage: rollback-chart-cast-39551 <chart-name> <hotfix-version>
+    local hotfix current name
+    name="$1"
+    hotfix="${name}-$2"
+    current=$(kubectl get deployments -n services "${name}" -o jsonpath='{.metadata.labels.helm\.sh/chart}')
+    if [[ ${current} != ${hotfix} ]]; then
+        echo "Current chart (${current}) does not match CAST-39551 hotfix chart (${hotfix})"
+        echo "Skipping rollback of ${name}"
+        return
+    fi
+    echo "Rolling back from ${current}"
+    helm -n services rollback "${name}"
+}
+
+# Rollback CFS
+rollback-chart-cast-39551 cray-cfs-api 1.23.7
+
+# Rollback cfs-operator
+rollback-chart-cast-39551 cray-cfs-operator 1.27.2
+```

--- a/hotfix/CAST-39551/docker/index.yaml
+++ b/hotfix/CAST-39551/docker/index.yaml
@@ -1,0 +1,21 @@
+artifactory.algol60.net/csm-docker/stable:
+  tls-verify: true
+  images:
+    cray-aee:
+    - 1.17.1
+    cray-cfs:
+    - 1.23.7
+    cray-cfs-operator:
+    - 1.27.2
+    cray-postgres-db-backup:
+    - 0.2.3
+    docker-kubectl:
+    - 1.24.17
+    docker.io/library/busybox:
+    - 1.28.0-glibc
+    docker.io/library/postgres:
+    - 13.2-alpine
+    docker.io/library/redis:
+    - 5.0-alpine
+    registry.opensource.zalan.do/acid/pgbouncer:
+    - master-21

--- a/hotfix/CAST-39551/helm/index.yaml
+++ b/hotfix/CAST-39551/helm/index.yaml
@@ -1,0 +1,6 @@
+https://artifactory.algol60.net/artifactory/csm-helm-charts/stable:
+  charts:
+    cray-cfs-api:
+    - 1.23.7
+    cray-cfs-operator:
+    - 1.27.2

--- a/hotfix/CAST-39551/install-hotfix.sh
+++ b/hotfix/CAST-39551/install-hotfix.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${ROOTDIR}/lib/version.sh"
+
+# Create scratch space
+workdir="$(mktemp -d)"
+trap "rm -fr '${workdir}'" EXIT
+
+# Build manifest
+cat > "${workdir}/manifest.yaml" << EOF
+apiVersion: manifests/v1beta1
+metadata:
+  name: ${RELEASE,,}
+spec:
+  sources:
+    charts:
+    - name: nexus
+      type: repo
+      location: https://packages.local/repository/charts
+  charts:
+  - name: cray-cfs-operator
+    version: 1.27.2
+    source: nexus
+    namespace: services
+  - name: cray-cfs-api
+    version: 1.23.7
+    source: nexus
+    namespace: services
+EOF
+
+# Extract customizations.yaml
+kubectl -n loftsman get secret site-init -o jsonpath='{.data.customizations\.yaml}' \
+    | base64 -d > "${workdir}/customizations.yaml"
+
+# manifestgen
+manifestgen -c "${workdir}/customizations.yaml" -i "${workdir}/manifest.yaml" -o "${workdir}/deploy-hotfix.yaml"
+
+# Load artifacts into nexus
+${ROOTDIR}/lib/setup-nexus.sh
+
+# Deploy chart
+loftsman ship --manifest-path "${workdir}/deploy-hotfix.yaml"
+
+set +x
+cat >&2 <<EOF
++ Hotfix installed
+${0##*/}: OK
+EOF

--- a/hotfix/CAST-39551/lib/install.sh
+++ b/hotfix/CAST-39551/lib/install.sh
@@ -1,0 +1,1 @@
+../../../vendor/github.hpe.com/hpe/hpc-shastarelm-release/lib/install.sh

--- a/hotfix/CAST-39551/lib/setup-nexus.sh
+++ b/hotfix/CAST-39551/lib/setup-nexus.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+set -exo pipefail
+
+ROOTDIR="$(dirname "${BASH_SOURCE[0]}")/.."
+source "${ROOTDIR}/lib/install.sh"
+
+load-install-deps
+
+# Upload assets to existing repositories
+skopeo-sync "${ROOTDIR}/docker"
+nexus-upload helm "${ROOTDIR}/helm" "${CHARTS_REPO:-"charts"}"
+
+clean-install-deps
+
+set +x
+cat >&2 <<EOF
++ Nexus setup complete
+setup-nexus.sh: OK
+EOF

--- a/hotfix/CAST-39551/lib/version.sh
+++ b/hotfix/CAST-39551/lib/version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# MIT License
+#
+# (C) Copyright 2026 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+: "${RELEASE:="${RELEASE_NAME:="CAST-39551"}-${RELEASE_VERSION:="1.6.2-20260310"}"}"
+
+# return if sourced
+return 0 2>/dev/null
+
+# otherwise print release information
+if [[ $# -eq 0 ]]; then
+    echo "$RELEASE"
+else
+    case "$1" in
+    -n|--name) echo "$RELEASE_NAME" ;;
+    -v|--version) echo "$RELEASE_VERSION" ;;
+    *)
+        echo >&2 "error: unsupported argument: $1"
+        echo >&2 "usage: ${0##*/} [--name|--version]"
+        ;;
+    esac
+fi


### PR DESCRIPTION
## Summary and Scope

This pulls in the patched versions of CFS and `cfs-operator` to address [CAST-39551](https://jira-pro.it.hpe.com:8443/browse/CAST-39551).

I tested this on `bradi` (which is installed with CSM 1.6.2). I did my original testing of the fix itself there, as well as the testing of the hotfix install and rollback.

For details on the exact contents of these two service versions, as well as my fix testing, see these PRs:
* https://github.com/Cray-HPE/config-framework-service/pull/241
* https://github.com/Cray-HPE/cfs-operator/pull/171

This is a simple hotfix since it just patches two services and does not involve any RPMs, image rebuilds, VCS configuration changes, etc.